### PR TITLE
Copy cylc logs if a suite test fails

### DIFF
--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -77,8 +77,9 @@ jobs:
     steps:
       - name: Copy cylc Logs
         run: |
-          cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
-
+          if [ -d "$HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
+          fi
 
   # Run hofx workflow
   # -----------------
@@ -124,8 +125,9 @@ jobs:
     steps:
       - name: Copy cylc Logs
         run: |
-          cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
-
+          if [ -d "$HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
+          fi
 
 # Perform all the clean up
 # ------------------------

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -66,6 +66,20 @@ jobs:
           swell_create_experiment ${EXPERIMENT_ID}.yaml
           swell_launch_experiment --suite_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+  # Copy cylc Logs upon failure
+  swell-tier_2-ufo_testing-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-ufo_testing
+    if: failure()
+
+    steps:
+      - name: Copy cylc Logs
+        run: |
+          cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
+
+
   # Run hofx workflow
   # -----------------
   swell-tier_1-hofx:
@@ -98,6 +112,20 @@ jobs:
           swell_prepare_experiment_config ${SUITE_NAME} -t stable_build -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell_create_experiment ${EXPERIMENT_ID}.yaml
           swell_launch_experiment --suite_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Copy cylc Logs upon failure
+  swell-tier_2-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-hofx
+    if: failure()
+
+    steps:
+      - name: Copy cylc Logs
+        run: |
+          cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
+
 
 # Perform all the clean up
 # ------------------------

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -77,6 +77,18 @@ jobs:
           # Create symbolic link to build that does not involve $GITHUB_RUN_ID
           ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
 
+  # Copy cylc logs upon failure
+  swell-tier_2-build_jedi-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-build_jedi
+    if: failure()
+
+    steps:
+      - name: Copy cylc logs
+        run: |
+          mv $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-build_jedi-${GITHUB_RUN_ID}-suite
 
   # ----------------------------------------
   # STEP2: RUN TESTING SUITES WITH NEW BUILD
@@ -118,6 +130,18 @@ jobs:
           swell_create_experiment ${EXPERIMENT_ID}.yaml
           swell_launch_experiment --suite_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+  # Copy cylc logs upon failure
+  swell-tier_2-convert_ncdiags-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-convert_ncdiags
+    if: failure()
+
+    steps:
+      - name: Copy cylc logs
+        run: |
+          cp -r $HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-convert_ncdiags-${GITHUB_RUN_ID}-suite
 
   # Run ufo_testing suite
   swell-tier_2-ufo_testing:
@@ -155,6 +179,20 @@ jobs:
           swell_create_experiment ${EXPERIMENT_ID}.yaml
           swell_launch_experiment --suite_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+  # Copy cylc logs upon failure
+  swell-tier_2-ufo_testing-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-ufo_testing
+    if: failure()
+
+    steps:
+      - name: Copy cylc logs
+        run: |
+          cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
+
+
   # Run hofx suite
   swell-tier_2-hofx:
 
@@ -190,6 +228,19 @@ jobs:
           swell_prepare_experiment_config ${SUITE_NAME} -t stable_build -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell_create_experiment ${EXPERIMENT_ID}.yaml
           swell_launch_experiment --suite_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Copy cylc logs upon failure
+  swell-tier_2-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-hofx
+    if: failure()
+
+    steps:
+      - name: Copy cylc logs
+        run: |
+          cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
 
 
   # -------------------------------------------------------------

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -88,7 +88,9 @@ jobs:
     steps:
       - name: Copy cylc logs
         run: |
-          mv $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-build_jedi-${GITHUB_RUN_ID}-suite
+          if [ -d "$HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-build_jedi-${GITHUB_RUN_ID}-suite
+          fi
 
   # ----------------------------------------
   # STEP2: RUN TESTING SUITES WITH NEW BUILD
@@ -141,7 +143,9 @@ jobs:
     steps:
       - name: Copy cylc logs
         run: |
-          cp -r $HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-convert_ncdiags-${GITHUB_RUN_ID}-suite
+          if [ -d "$HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-convert_ncdiags-${GITHUB_RUN_ID}-suite
+          fi
 
   # Run ufo_testing suite
   swell-tier_2-ufo_testing:
@@ -190,8 +194,9 @@ jobs:
     steps:
       - name: Copy cylc logs
         run: |
-          cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
-
+          if [ -d "$HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-ufo_testing-${GITHUB_RUN_ID}-suite
+          fi
 
   # Run hofx suite
   swell-tier_2-hofx:
@@ -240,8 +245,9 @@ jobs:
     steps:
       - name: Copy cylc logs
         run: |
-          cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
-
+          if [ -d "$HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite" ]; then
+            cp -r $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}/cylc_logs-swell-hofx-${GITHUB_RUN_ID}-suite
+          fi
 
   # -------------------------------------------------------------
   # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP


### PR DESCRIPTION
When a suite test fails we may want to review the logs from Cylc. This adds new tasks that run on failure of each suite and copies the cylc files to the experiment directories