### PR TITLE
Add comparison tests to tier2

### DIFF
--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -63,7 +63,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
@@ -121,7 +121,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
@@ -175,7 +175,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
@@ -218,7 +218,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
@@ -278,7 +278,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
@@ -321,7 +321,7 @@ jobs:
           source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages


### PR DESCRIPTION
This PR introduces swell comparison tests to tier2. Comparisons are run between pinned `3dfgat_cycle` and `3dfgat_atmos` suites living in the `gmao_ci` nobackup, and those experiments run nightly in tier2. This allows us to assess the differences between the current develop branch of swell, and a past pinned version. Most differences will be created by changes made to JEDI. The task `JediLogComparison` is designed to fail if it detects relatively small differences in `Residual norm` in JEDI output between experiments, so we expect this to trip up somewhat frequently. 

This has been tested on the test branch, which succeeded on the https://github.com/GEOS-ESM/swell/pull/676 branch of swell

https://github.com/GEOS-ESM/swell/actions/runs/20149808153

Depends on:
- [x] https://github.com/GEOS-ESM/swell/pull/676
