### PR TITLE
Use matrices for tier2 tests, compare against last stable version and publish results

### DIFF
--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -6,426 +6,104 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
+
 jobs:
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda", "hofx_cf"]'
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda hofx_cf" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  # ------------------------------------------
   swell-tier_1-setup:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-
+    needs: define-matrix
     steps:
       - name: validate-workflow
-        run: |
-          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
-          # Remove source code (needed to ensure nothing relies on the source)
+          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
 
-  # Run 3dvar_cycle workflow
-  # ------------------------
-  swell-tier_1-3dvar_cycle:
-
+  # Run all test workflows using matrix
+  swell-tier_1-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: [define-matrix, swell-tier_1-setup]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-3dvar_cycle
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          EOF
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_cycle
+      - name: Mark failed on failure
+        if: failure()
         run: |
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Run 3dfgat_cycle workflow
-  # ------------------------
-  swell-tier_1-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
-
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar
-        run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_atmos
-        run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-
-  # Run localensembleda workflow
-  # -----------------
-  swell-tier_1-localensembleda:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-localensembleda
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-localensembleda-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-localensembleda
-    if: failure()
-
-    steps:
-      - name: Fail hold for localensembleda
-        run: |
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-# Perform all the clean up
-# ------------------------
-
+  # Cleanup on success
   swell-tier_1-clean_up_success:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos, swell-tier_1-localensembleda]
-
+    needs: [define-matrix, swell-tier_1-test]
     steps:
-
       - name: Remove the run directory
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
+  # Cleanup always (cylc logs)
   swell-tier_1-clean_up_always:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos, swell-tier_1-localensembleda]
-    if: always()  # Always run the clean up, even if failed or cancelled
-
+    needs: [define-matrix, swell-tier_1-test]
+    if: always()
     steps:
-
-      - name: Remove the cylc logging directories
+      - name: Remove cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-localensembleda-${GITHUB_RUN_ID}-suite
-
-      - name: Remove the R2D2 experiment output
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
+          done

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -226,7 +226,9 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_cycle-comparison")
+          echo "publish_directory: ~/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/3dfgat_cycle-comparison/swell-3dfgat_cycle-comparison-*/swell-3dfgat_cycle-comparison-*-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
           COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
@@ -327,8 +329,9 @@ jobs:
 
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "publish_directory: ~/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_atmos-comparison")
+            COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/3dfgat_atmos-comparison/swell-3dfgat_atmos-comparison-*/swell-3dfgat_atmos-comparison-*-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
           COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
@@ -368,7 +371,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier_2-3dfgat_atmos-comparison, swell-tier_2-3dfgat_cycle-comparison]
 
     steps:
       - name: Replace link to stable with link to current run and remove old directory

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -8,13 +8,40 @@ defaults:
 
 jobs:
 
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES='["hofx", "3dfgat_cycle", "3dfgat_atmos"]'
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=hofx 3dfgat_cycle 3dfgat_atmos" >> $GITHUB_OUTPUT
+
+  define-comparison-matrix:
+    runs-on: nccs-discover
+    outputs:
+      comparison_suites: ${{ steps.set-suites.out
+      comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
+    steps:
+      - name: Set comparison suite list
+        id: set-comparison-suites
+        run: |
+          SUITES='["3dfgat_cycle", "3dfgat_atmos"]'
+          echo "comparison_suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "comparison_suites_space=3dfgat_cycle-comparison 3dfgat_atmos-comparison" >> $GITHUB_OUTPUT
+
   # Initialization needed by all the workflows
   # ------------------------------------------
   swell-tier_2-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-
+    needs: define-matrix
     steps:
       - name: validate-workflow
         run: |
@@ -99,116 +126,75 @@ jobs:
   # ----------------------------------------
   # STEP2: RUN TESTING SUITES WITH NEW BUILD
   # ----------------------------------------
-
-  # Run hofx suite
-  swell-tier_2-hofx:
-
+  swell-tier_2-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-hofx
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
+          EXPERIMENT_ID=swell${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
           PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+        export PATH=$CI_WORKSPACE/swell/bin:$PATH
+        export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+        cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+        experiment_id: $EXPERIMENT_ID
+        experiment_root: $CI_WORKSPACE_JOB
+        existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
+        existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
+        EOF
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+        rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+        cd $CI_WORKSPACE_JOB
+        swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
+        swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+      - name: Mark failed on failure
+        if: failure()
+        run: |
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
+
+  swell-tier2-comparison:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-hofx
-    if: failure()
+    needs: [define-comparison-matrix, swell-tier_2-setup, swell-tier_2-test]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-comparison-matrix.outputs.comparison_suites) }}
 
     steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_cycle suite
-  swell-tier_2-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_cycle-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
-
-    steps:
-      - name: run-swell-3dfgat_cycle-comparison
+      - name: run-swell-${{ matrix.suite }}-comparison
         run: |
 
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           
-          COMPARISON_SUITE=3dfgat_cycle
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
+          SUITE_NAME=${{ matrix.suite }}-comparison
 
-          CONFIG_NAME=compare_fgat_marine
+          if [ "${{ matrix.suite }}" = "3dfgat_cycle" ]; then
+            CONFIG_NAME=compare_fgat_marine
+          else
+            CONFIG_NAME=compare_variational_atmosphere
 
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
@@ -226,7 +212,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          echo "publish_directory: ~/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/3dfgat_cycle-comparison/swell-3dfgat_cycle-comparison-*/swell-3dfgat_cycle-comparison-*-suite/experiment.yaml
 
@@ -243,124 +229,6 @@ jobs:
           swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME}_tier2 -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_atmos-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-
-    steps:
-      - name: run-swell-3dfgat_atmos-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_atmos
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_variational_atmosphere
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "publish_directory: ~/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-            COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/3dfgat_atmos-comparison/swell-3dfgat_atmos-comparison-*/swell-3dfgat_atmos-comparison-*-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-  
   # -------------------------------------------------------------
   # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
   # -------------------------------------------------------------
@@ -371,7 +239,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier_2-3dfgat_atmos-comparison, swell-tier_2-3dfgat_cycle-comparison]
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
 
     steps:
       - name: Replace link to stable with link to current run and remove old directory
@@ -401,11 +269,10 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
-
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -149,21 +149,21 @@ jobs:
 
           PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
-        export PATH=$CI_WORKSPACE/swell/bin:$PATH
-        export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-        cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
-        experiment_id: $EXPERIMENT_ID
-        experiment_root: $CI_WORKSPACE_JOB
-        existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
-        existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
-        EOF
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
+          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
+          EOF
 
-        rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
-        cd $CI_WORKSPACE_JOB
-        swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
-        swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
       - name: Mark failed on failure
         if: failure()
@@ -214,7 +214,7 @@ jobs:
 
           echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/3dfgat_cycle-comparison/swell-3dfgat_cycle-comparison-*/swell-3dfgat_cycle-comparison-*-suite/experiment.yaml
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/${SUITE_NAME}/swell-${SUITE_NAME}-*/swell-${SUITE_NAME}-*-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
           COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -6,6 +6,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier2
+
 jobs:
 
   # Define the suite list once
@@ -25,7 +28,7 @@ jobs:
   define-comparison-matrix:
     runs-on: nccs-discover
     outputs:
-      comparison_suites: ${{ steps.set-suites.out
+      comparison_suites: ${{ steps.set-comparison-suites.outputs.comparisons_suites }}
       comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
     steps:
       - name: Set comparison suite list
@@ -129,7 +132,7 @@ jobs:
   swell-tier_2-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
+    needs: [define-matrix, swell-tier_2-build_jedi]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -142,7 +145,7 @@ jobs:
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
-          EXPERIMENT_ID=swell${SUITE_NAME}-${GITHUB_RUN_ID}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
           source ${CI_WORKSPACE}/modules
@@ -155,14 +158,14 @@ jobs:
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
-          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
-          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
+          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source
+          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
       - name: Mark failed on failure
@@ -172,11 +175,11 @@ jobs:
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
 
-  swell-tier2-comparison:
+  swell-tier_2-comparison:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-comparison-matrix, swell-tier_2-setup, swell-tier_2-test]
+    needs: [define-comparison-matrix, swell-tier_2-test]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -191,7 +194,7 @@ jobs:
           
           SUITE_NAME=${{ matrix.suite }}-comparison
 
-          if [ "${{ matrix.suite }}" = "3dfgat_cycle" ]; then
+          if [ "${{ matrix.suite }}" == "3dfgat_cycle" ]; then
             CONFIG_NAME=compare_fgat_marine
           else
             CONFIG_NAME=compare_variational_atmosphere
@@ -211,7 +214,6 @@ jobs:
 
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
           echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/${SUITE_NAME}/swell-${SUITE_NAME}-*/swell-${SUITE_NAME}-*-suite/experiment.yaml


### PR DESCRIPTION
This PR updates the tier2 tests to use the matrix structure introduced in #29. It also enables comparison testing against the latest stable run of tier2 tests. We can update swell to use the build of JEDI from the latest stable tier2 tests, which will allow the build to be automatically updated if it passes with zero diff. The `publish_comparisons` task introduced in https://github.com/GEOS-ESM/swell/pull/702 will post the results to dataportal if it isn't zero diff.

This is a draft for now, I haven't tested this as I want to get #29 in before overwriting the test branch