### PR TITLE
rename marine suites, prepare for 3dvar_cf

### DIFF
--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -6,10 +6,8 @@ defaults:
   run:
     shell: bash
 
-env:
-  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
-
 jobs:
+
   # Define the suite list once
   define-matrix:
     runs-on: nccs-discover
@@ -20,36 +18,121 @@ jobs:
       - name: Set suite list
         id: set-suites
         run: |
-          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda"]'
+          SUITES='["hofx", "3dfgat_cycle", "3dfgat_atmos"]'
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda" >> $GITHUB_OUTPUT
+          echo "suites_space=hofx 3dfgat_cycle 3dfgat_atmos" >> $GITHUB_OUTPUT
+
+  define-comparison-matrix:
+    runs-on: nccs-discover
+    outputs:
+      comparison_suites: ${{ steps.set-comparison-suites.out }}
+      comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
+    steps:
+      - name: Set comparison suite list
+        id: set-comparison-suites
+        run: |
+          SUITES='["3dfgat_cycle", "3dfgat_atmos"]'
+          echo "comparison_suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "comparison_suites_space=3dfgat_cycle-comparison 3dfgat_atmos-comparison" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  swell-tier_1-setup:
+  # ------------------------------------------
+  swell-tier_2-setup:
+
     runs-on: nccs-discover
     timeout-minutes: 30
     needs: define-matrix
     steps:
       - name: validate-workflow
-        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+        run: |
+          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
-          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
-          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Make experiment directory
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          # Copy and source modules
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run all test workflows using matrix
-  swell-tier_1-test:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
+
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: [define-matrix, swell-tier_1-setup]
+    needs: swell-tier_2-setup
+
+    steps:
+
+      - name: run-swell-build_jedi
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
+  # Move experiment directory on failure
+  swell-tier_2-build_jedi-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-build_jedi
+    if: failure()
+
+    steps:
+      - name: Fail hold for build_jedi
+        run: |
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+  swell-tier_2-test:
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
@@ -59,24 +142,27 @@ jobs:
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          EXPERIMENT_ID=swell${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
           source ${CI_WORKSPACE}/modules
 
-          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
+          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
+          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
       - name: Mark failed on failure
@@ -85,30 +171,119 @@ jobs:
           CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Cleanup on success
-  swell-tier_1-clean_up_success:
+
+  swell-tier2-comparison:
+
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-matrix, swell-tier_1-test]
-    steps:
-      - name: Remove the run directory
-        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+    needs: [define-comparison-matrix, swell-tier_2-setup, swell-tier_2-test]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-comparison-matrix.outputs.comparison_suites) }}
 
-  # Cleanup always (cylc logs and R2D2)
-  swell-tier_1-clean_up_always:
+    steps:
+      - name: run-swell-${{ matrix.suite }}-comparison
+        run: |
+
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          SUITE_NAME=${{ matrix.suite }}-comparison
+
+          if [ "${{ matrix.suite }}" == "3dfgat_cycle" ]; then
+            CONFIG_NAME=compare_fgat_marine
+          else
+            CONFIG_NAME=compare_variational_atmosphere
+
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/${SUITE_NAME}/swell-${SUITE_NAME}-*/swell-${SUITE_NAME}-*-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
+
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
+
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-matrix, swell-tier_1-test]
-    if: always()
-    steps:
-      - name: Remove cylc logging directories
-        run: |
-          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
-            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
-          done
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
 
-      - name: Remove R2D2 experiment output
+    steps:
+      - name: Replace link to stable with link to current run and remove old directory
         run: |
-          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
-            rm -rf /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${suite}-${GITHUB_RUN_ID}
-          done
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
+
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
+        run: |
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
+
+  swell-tier_2-clean_up:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
+    if: always()  # Always run the clean up, even if failed or cancelled
+
+    steps:
+      - name: Remove the cylc logging directories
+        run: |
+          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
+
+      - name: Remove the R2D2 experiment output
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -1,28 +1,272 @@
-# This is a utility workflow for validating on-prem access.
+name: Swell Tier 1 Applications Tests (Discover)
 
-name: discover-validate
-
-on:
-  workflow_call:
-    inputs:
-      accessor:
-        required: true
-        type: string
-      project:
-        required: true
-        type: string
+on: workflow_call
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  discover-validate:
-  
+
+  # Initialization needed by all the workflows
+  # ------------------------------------------
+  swell-tier_1-setup:
+
     runs-on: nccs-discover
-    
+    timeout-minutes: 30
+
     steps:
-    
       - name: validate-workflow
         run: |
-          /home/jardizzo/bin/nams_check.py ${{ inputs.accessor }} ${{ inputs.project }}
+          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+
+      - name: acquire-swell
+        uses: actions/checkout@v3
+
+      - name: install-swell
+        run: |
+          # Make experiment directory
+          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          # Copy and source modules
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Remove source code (needed to ensure nothing relies on the source)
+
+  # Run ufo_testing workflow
+  # ------------------------
+  swell-tier_1-ufo_testing:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-ufo_testing
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-ufo_testing-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-ufo_testing
+    if: failure()
+
+    steps:
+      - name: Fail hold for ufo_testing
+        run: |
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
+
+  # Run hofx workflow
+  # -----------------
+  swell-tier_1-hofx:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-hofx
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-hofx
+    if: failure()
+
+    steps:
+      - name: Fail hold for hofx
+        run: |
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar workflow
+  # -----------------
+  swell-tier_1-3dvar:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar
+        run: |
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+# Perform all the clean up
+# ------------------------
+
+  swell-tier_1-clean_up_success:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+
+    steps:
+
+      - name: Remove the run directory
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+
+  swell-tier_1-clean_up_always:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    if: always()  # Always run the clean up, even if failed or cancelled
+
+    steps:
+
+      - name: Remove the cylc logging directories
+        run: |
+          rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+
+      - name: Remove the R2D2 experiment output
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -1,0 +1,28 @@
+# This is a utility workflow for validating on-prem access.
+
+name: discover-validate
+
+on:
+  workflow_call:
+    inputs:
+      accessor:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  discover-validate:
+  
+    runs-on: nccs-discover
+    
+    steps:
+    
+      - name: validate-workflow
+        run: |
+          /home/jardizzo/bin/nams_check.py ${{ inputs.accessor }} ${{ inputs.project }}

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 2 Applications Tests (Discover)
+name: Swell Tier 1 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -6,417 +6,109 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
+
 jobs:
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda"]'
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  # ------------------------------------------
-  swell-tier_2-setup:
-
+  swell-tier_1-setup:
     runs-on: nccs-discover
     timeout-minutes: 30
-
+    needs: define-matrix
     steps:
       - name: validate-workflow
-        run: |
-          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
-
-      # Only one tier 2 run is allowed at a given time
-      - name: establish-workflow-status
-        run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
-          # Remove source code (needed to ensure nothing relies on the source)
+          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
 
-  # --------------------------------------------
-  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
-  # --------------------------------------------
-
-  swell-tier_2-build_jedi:
-
+  # Run all test workflows using matrix
+  swell-tier_1-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
+    needs: [define-matrix, swell-tier_1-setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-build_jedi
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          EOF
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+      - name: Mark failed on failure
+        if: failure()
+        run: |
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Move experiment directory on failure
-  swell-tier_2-build_jedi-failure:
-
+  # Cleanup on success
+  swell-tier_1-clean_up_success:
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-build_jedi
-    if: failure()
-
+    needs: [define-matrix, swell-tier_1-test]
     steps:
-      - name: Fail hold for build_jedi
-        run: |
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+      - name: Remove the run directory
+        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-
-  # Run hofx suite
-  swell-tier_2-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
-
+  # Cleanup always (cylc logs and R2D2)
+  swell-tier_1-clean_up_always:
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-hofx
-    if: failure()
-
+    needs: [define-matrix, swell-tier_1-test]
+    if: always()
     steps:
-      - name: Fail hold for hofx
+      - name: Remove cylc logging directories
         run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
+          done
 
-  # Run 3dfgat_cycle suite
-  swell-tier_2-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
+      - name: Remove R2D2 experiment output
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_cycle-comparison:
-
-    runs_on: nccs-discover
-    timeout_minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
-
-    steps:
-      - name: run-swell-3dfgat_cycle-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_cycle
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_variational_marine
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_atmos-comparison:
-
-    runs_on: nccs-discover
-    timeout_minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-
-    steps:
-      - name: run-swell-3dfgat_atmos-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_atmos
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_variational_atmosphere
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-  
-  # -------------------------------------------------------------
-  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
-  # -------------------------------------------------------------
-
-  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
-  # --------------------------
-  swell-tier_2-update_if_stable:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
-
-    steps:
-      - name: Replace link to stable with link to current run and remove old directory
-        run: |
-          # Get full path to previous sucessful run
-          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
-
-          # Remove link
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
-
-          # Link to new stable
-          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
-
-          # Remove old stable
-          echo "Removing previous stable: $previous_stable"
-          rm -r -f $previous_stable
-
-      # Remove the running lock if the update was sucessful
-      - name: Remove the running lock
-        run: |
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
-
-  # Perform all the clean up (always runs regardless of success of failure)
-  # ------------------------
-
-  swell-tier_2-clean_up:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
-    if: always()  # Always run the clean up, even if failed or cancelled
-
-    steps:
-
-      - name: Remove the cylc logging directories
-        run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
-
-      - name: Remove the R2D2 experiment output
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${suite}-${GITHUB_RUN_ID}
+          done

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -215,6 +215,8 @@ jobs:
 
           mkdir -p $CI_WORKSPACE_JOB
 
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
@@ -228,7 +230,7 @@ jobs:
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
 
           echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
@@ -316,6 +318,8 @@ jobs:
 
           mkdir -p $CI_WORKSPACE_JOB
 
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
@@ -329,7 +333,7 @@ jobs:
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
 
           echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -236,6 +236,56 @@ jobs:
         run: |
           SUITE_NAME=3dvar_atmos
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_atmos
+        run: |
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
 # Perform all the clean up
@@ -245,7 +295,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
 
     steps:
 
@@ -257,7 +307,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -266,6 +316,9 @@ jobs:
         run: |
           rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |

--- a/.github/test_swell.yml
+++ b/.github/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_1-setup:
+  swell-tier_2-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,39 +20,47 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run ufo_testing workflow
-  # ------------------------
-  swell-tier_1-ufo_testing:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-setup
 
     steps:
 
-      - name: run-swell-ufo_testing
+      - name: run-swell-build_jedi
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -66,45 +74,51 @@ jobs:
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
   # Move experiment directory on failure
-  swell-tier_1-ufo_testing-failure:
+  swell-tier_2-build_jedi-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-ufo_testing
+    needs: swell-tier_2-build_jedi
     if: failure()
 
     steps:
-      - name: Fail hold for ufo_testing
+      - name: Fail hold for build_jedi
         run: |
-          SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
 
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+
+  # Run hofx suite
+  swell-tier_2-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-hofx
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -115,47 +129,50 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
+  swell-tier_2-hofx-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-hofx
+    needs: swell-tier_2-hofx
     if: failure()
 
     steps:
       - name: Fail hold for hofx
         run: |
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
+  # Run 3dfgat_cycle suite
+  swell-tier_2-3dfgat_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
-      - name: run-swell-3dvar
+      - name: run-swell-3dfgat_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -166,47 +183,37 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
+  swell-tier2-3dfgat_cycle-comparison:
 
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
+    runs_on: nccs-discover
+    timeout_minutes: 30
+    needs: swell-tier_2-3dfgat_cycle
 
     steps:
-      - name: Fail hold for 3dvar
+      - name: run-swell-3dfgat_cycle-comparison
         run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          COMPARISON_SUITE=3dfgat_cycle
+          SUITE_NAME=${COMPARISON_SUITE}-comparison
 
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+          CONFIG_NAME=compare_variational_marine
 
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -217,46 +224,56 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
+  swell-tier_2-3dfgat_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
+    needs: swell-tier_2-3dfgat_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for 3dvar_atmos
+      - name: Fail hold for 3dfgat_cycle
         run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
+  # Run 3dfgat_atmos suite
+  swell-tier_2-3dfgat_atmos:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-3dfgat_atmos
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -267,59 +284,135 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  swell-tier2-3dfgat_atmos-comparison:
+
+    runs_on: nccs-discover
+    timeout_minutes: 30
+    needs: swell-tier_2-3dfgat_atmos
+
+    steps:
+      - name: run-swell-3dfgat_atmos-comparison
+        run: |
+
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          COMPARISON_SUITE=3dfgat_atmos
+          SUITE_NAME=${COMPARISON_SUITE}-comparison
+
+          CONFIG_NAME=compare_variational_atmosphere
+
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
+  swell-tier_2-3dfgat_atmos-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
+    needs: swell-tier_2-3dfgat_atmos
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_atmos
         run: |
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+  
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
 
-# Perform all the clean up
-# ------------------------
-
-  swell-tier_1-clean_up_success:
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
 
     steps:
-
-      - name: Remove the run directory
+      - name: Replace link to stable with link to current run and remove old directory
         run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
 
-  swell-tier_1-clean_up_always:
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
+
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
+        run: |
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
+
+  swell-tier_2-clean_up:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -28,14 +28,14 @@ jobs:
           # Make experiment directory
           mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
           source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
           pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run ufo_testing workflow
+  # Run 3dvar_cycle workflow
   # ------------------------
-  swell-tier_1-ufo_testing:
+  swell-tier_1-3dvar_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
@@ -43,10 +43,10 @@ jobs:
 
     steps:
 
-      - name: run-swell-ufo_testing
+      - name: run-swell-3dvar_cycle
         run: |
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=ufo_testing
+          SUITE_NAME=3dvar_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
@@ -66,21 +66,73 @@ jobs:
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-ufo_testing-failure:
+  swell-tier_1-3dvar_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-ufo_testing
+    needs: swell-tier_1-3dvar_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for ufo_testing
+      - name: Fail hold for 3dvar_cycle
         run: |
-          SUITE_NAME=ufo_testing
+          SUITE_NAME=3dvar_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
+
+  # Run 3dfgat_cycle workflow
+  # ------------------------
+  swell-tier_1-3dfgat_cycle:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_cycle
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_cycle-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_cycle
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_cycle
+        run: |
+          SUITE_NAME=3dfgat_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
                 - name: Copy cylc Logs
@@ -118,7 +170,7 @@ jobs:
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
@@ -169,7 +221,7 @@ jobs:
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
@@ -187,6 +239,107 @@ jobs:
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_atmos
+        run: |
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
 # Perform all the clean up
 # ------------------------
 
@@ -194,7 +347,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
 
     steps:
 
@@ -206,15 +359,19 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [define-matrix, swell-tier_1-setup]
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 6
       matrix:
         suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -6,373 +6,127 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
+
 jobs:
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES_ARR=(
+            "3dvar_marine_cycle"
+            "3dfgat_marine_cycle"
+            "hofx"
+            "3dvar_marine"
+            "3dvar_atmos"
+            "3dfgat_atmos"
+            "localensembleda"
+            "hofx_cf"
+            # "3dvar_cf"
+          )
+          
+          # Build JSON array explicitly (because jq command doesn't exist)
+          SUITES='["'
+          for i in "${!SUITES_ARR[@]}"; do
+            if [ $i -lt $((${#SUITES_ARR[@]} - 1)) ]; then
+              SUITES+="${SUITES_ARR[$i]}\",\""
+            else
+              SUITES+="${SUITES_ARR[$i]}"
+            fi
+          done
+          SUITES+='"]'
+          
+          SUITES_SPACE="${SUITES_ARR[*]}"
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=$SUITES_SPACE" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  # ------------------------------------------
   swell-tier_1-setup:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-
+    needs: define-matrix
     steps:
       - name: validate-workflow
-        run: |
-          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
-          # Remove source code (needed to ensure nothing relies on the source)
+          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
 
-  # Run 3dvar_cycle workflow
-  # ------------------------
-  swell-tier_1-3dvar_cycle:
-
+  # Run all test workflows using matrix
+  swell-tier_1-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: [define-matrix, swell-tier_1-setup]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-3dvar_cycle
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          EOF
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_cycle
+      - name: Mark failed on failure
+        if: failure()
         run: |
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Run 3dfgat_cycle workflow
-  # ------------------------
-  swell-tier_1-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
-
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar
-        run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_atmos
-        run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-# Perform all the clean up
-# ------------------------
-
+  # Cleanup on success
   swell-tier_1-clean_up_success:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
-
+    needs: [define-matrix, swell-tier_1-test]
     steps:
-
       - name: Remove the run directory
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
+  # Cleanup always (cylc logs)
   swell-tier_1-clean_up_always:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
-    if: always()  # Always run the clean up, even if failed or cancelled
-
+    needs: [define-matrix, swell-tier_1-test]
+    if: always()
     steps:
-
-      - name: Remove the cylc logging directories
+      - name: Remove cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-
-      - name: Remove the R2D2 experiment output
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
+          done

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -39,6 +39,30 @@ jobs:
           pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
+
+  check_hash_on_discover_test:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_2-setup
+
+    steps:
+
+      - name: run-check_hash_test
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          #run check hash test script
+          python $CI_WORKSPACE/swell/lib/python$PYVER/site-packages/swell/test/platform_tests/check_hashes_discover.py
+
+
   # --------------------------------------------
   # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
   # --------------------------------------------

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 2 Applications Tests (Discover)
+name: Swell Tier 1 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_2-setup:
+  swell-tier_1-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,47 +20,39 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
-      # Only one tier 2 run is allowed at a given time
-      - name: establish-workflow-status
-        run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
-
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # --------------------------------------------
-  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
-  # --------------------------------------------
-
-  swell-tier_2-build_jedi:
+  # Run 3dvar_cycle workflow
+  # ------------------------
+  swell-tier_1-3dvar_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
+    needs: swell-tier_1-setup
 
     steps:
 
-      - name: run-swell-build_jedi
+      - name: run-swell-3dvar_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -77,102 +69,42 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
-
   # Move experiment directory on failure
-  swell-tier_2-build_jedi-failure:
+  swell-tier_1-3dvar_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-3dvar_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for build_jedi
+      - name: Fail hold for 3dvar_cycle
         run: |
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=3dvar_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
 
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-
-  # Run hofx suite
-  swell-tier_2-hofx:
+  # Run 3dfgat_cycle workflow
+  # ------------------------
+  swell-tier_1-3dfgat_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_cycle suite
-  swell-tier_2-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
 
     steps:
 
       - name: run-swell-3dfgat_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -183,10 +115,6 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -194,39 +122,41 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-3dfgat_cycle-failure:
+  swell-tier_1-3dfgat_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
+    needs: swell-tier_1-3dfgat_cycle
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_cycle
         run: |
           SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
 
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
+  # Run hofx workflow
+  # -----------------
+  swell-tier_1-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
 
     steps:
 
-      - name: run-swell-3dfgat_atmos
+      - name: run-swell-hofx
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -237,9 +167,56 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-hofx
+    if: failure()
+
+    steps:
+      - name: Fail hold for hofx
+        run: |
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar workflow
+  # -----------------
+  swell-tier_1-3dvar:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
@@ -248,61 +225,206 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
+  swell-tier_1-3dvar-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
+    needs: swell-tier_1-3dvar
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar
+        run: |
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_atmos
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_atmos
         run: |
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-  
-  # -------------------------------------------------------------
-  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
-  # -------------------------------------------------------------
 
-  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
-  # --------------------------
-  swell-tier_2-update_if_stable:
+  # Run localensembleda workflow
+  # -----------------
+  swell-tier_1-localensembleda:
 
     runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
 
     steps:
-      - name: Replace link to stable with link to current run and remove old directory
+
+      - name: run-swell-localensembleda
         run: |
-          # Get full path to previous sucessful run
-          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=localensembleda
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
-          # Remove link
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+          mkdir -p $CI_WORKSPACE_JOB
 
-          # Link to new stable
-          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
-          # Remove old stable
-          echo "Removing previous stable: $previous_stable"
-          rm -r -f $previous_stable
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
-      # Remove the running lock if the update was sucessful
-      - name: Remove the running lock
-        run: |
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-  # Perform all the clean up (always runs regardless of success of failure)
-  # ------------------------
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-  swell-tier_2-clean_up:
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-localensembleda-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
+    needs: swell-tier_1-localensembleda
+    if: failure()
+
+    steps:
+      - name: Fail hold for localensembleda
+        run: |
+          SUITE_NAME=localensembleda
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+# Perform all the clean up
+# ------------------------
+
+  swell-tier_1-clean_up_success:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs:
+          - swell-tier_1-3dvar_cycle
+          - swell-tier_1-3dfgat_cycle
+          - swell-tier_1-hofx
+          - swell-tier_1-3dvar
+          - swell-tier_1-3dvar_atmos
+          - swell-tier_1-3dfgat_atmos
+          - swell-tier_1-localensembleda
+
+    steps:
+
+      - name: Remove the run directory
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+
+  swell-tier_1-clean_up_always:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs:
+          - swell-tier_1-3dvar_cycle
+          - swell-tier_1-3dfgat_cycle
+          - swell-tier_1-hofx
+          - swell-tier_1-3dvar
+          - swell-tier_1-3dvar_atmos
+          - swell-tier_1-3dfgat_atmos
+          - swell-tier_1-localensembleda
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -310,13 +432,13 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-localsensembleda-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -269,7 +269,7 @@ jobs:
       - name: run-swell-3dfgat_atmos
         run: |
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos_tier2
+          SUITE_NAME=3dfgat_atmos
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
@@ -293,7 +293,7 @@ jobs:
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME}_tier2 -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   swell-tier2-3dfgat_atmos-comparison:

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -165,7 +165,7 @@ jobs:
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
       - name: Mark failed on failure

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -6,10 +6,8 @@ defaults:
   run:
     shell: bash
 
-env:
-  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
-
 jobs:
+
   # Define the suite list once
   define-matrix:
     runs-on: nccs-discover
@@ -20,34 +18,118 @@ jobs:
       - name: Set suite list
         id: set-suites
         run: |
-          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda", "hofx_cf"]'
+          SUITES='["hofx", "3dfgat_cycle", "3dfgat_atmos"]'
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda hofx_cf" >> $GITHUB_OUTPUT
+          echo "suites_space=hofx 3dfgat_cycle 3dfgat_atmos" >> $GITHUB_OUTPUT
+
+  define-comparison-matrix:
+    runs-on: nccs-discover
+    outputs:
+      comparison_suites: ${{ steps.set-comparison-suites.out }}
+      comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
+    steps:
+      - name: Set comparison suite list
+        id: set-comparison-suites
+        run: |
+          SUITES='["3dfgat_cycle", "3dfgat_atmos"]'
+          echo "comparison_suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "comparison_suites_space=3dfgat_cycle-comparison 3dfgat_atmos-comparison" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  swell-tier_1-setup:
+  # ------------------------------------------
+  swell-tier_2-setup:
+
     runs-on: nccs-discover
     timeout-minutes: 30
     needs: define-matrix
     steps:
       - name: validate-workflow
-        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+        run: |
+          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
-          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
-          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Make experiment directory
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          # Copy and source modules
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run all test workflows using matrix
-  swell-tier_1-test:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
+
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: [define-matrix, swell-tier_1-setup]
+    needs: swell-tier_2-setup
+
+    steps:
+
+      - name: run-swell-build_jedi
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
+  # Move experiment directory on failure
+  swell-tier_2-build_jedi-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-build_jedi
+    if: failure()
+
+    steps:
+      - name: Fail hold for build_jedi
+        run: |
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+  swell-tier_2-test:
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -60,24 +142,27 @@ jobs:
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          EXPERIMENT_ID=swell${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
           source ${CI_WORKSPACE}/modules
 
-          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
+          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
+          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
       - name: Mark failed on failure
@@ -86,24 +171,119 @@ jobs:
           CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Cleanup on success
-  swell-tier_1-clean_up_success:
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [define-matrix, swell-tier_1-test]
-    steps:
-      - name: Remove the run directory
-        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
-  # Cleanup always (cylc logs)
-  swell-tier_1-clean_up_always:
+  swell-tier_2-comparison:
+
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-matrix, swell-tier_1-test]
-    if: always()
+    needs: [define-comparison-matrix, swell-tier_2-setup, swell-tier_2-test]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        suite: ${{ fromJson(needs.define-comparison-matrix.outputs.comparison_suites) }}
+
     steps:
-      - name: Remove cylc logging directories
+      - name: run-swell-${{ matrix.suite }}-comparison
         run: |
-          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
-            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
-          done
+
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          SUITE_NAME=${{ matrix.suite }}-comparison
+
+          if [ "${{ matrix.suite }}" == "3dfgat_cycle" ]; then
+            CONFIG_NAME=compare_fgat_marine
+          else
+            CONFIG_NAME=compare_variational_atmosphere
+
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/${SUITE_NAME}/swell-${SUITE_NAME}-*/swell-${SUITE_NAME}-*-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
+
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
+
+    steps:
+      - name: Replace link to stable with link to current run and remove old directory
+        run: |
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
+
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
+        run: |
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
+
+  swell-tier_2-clean_up:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
+    if: always()  # Always run the clean up, even if failed or cancelled
+
+    steps:
+      - name: Remove the cylc logging directories
+        run: |
+          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
+
+      - name: Remove the R2D2 experiment output
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,0 +1,272 @@
+name: Swell Tier 1 Applications Tests (Discover)
+
+on: workflow_call
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  # Initialization needed by all the workflows
+  # ------------------------------------------
+  swell-tier_1-setup:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+
+    steps:
+      - name: validate-workflow
+        run: |
+          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+
+      - name: acquire-swell
+        uses: actions/checkout@v3
+
+      - name: install-swell
+        run: |
+          # Make experiment directory
+          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          # Copy and source modules
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          # Remove source code (needed to ensure nothing relies on the source)
+
+  # Run ufo_testing workflow
+  # ------------------------
+  swell-tier_1-ufo_testing:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-ufo_testing
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-ufo_testing-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-ufo_testing
+    if: failure()
+
+    steps:
+      - name: Fail hold for ufo_testing
+        run: |
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
+
+  # Run hofx workflow
+  # -----------------
+  swell-tier_1-hofx:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-hofx
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-hofx
+    if: failure()
+
+    steps:
+      - name: Fail hold for hofx
+        run: |
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar workflow
+  # -----------------
+  swell-tier_1-3dvar:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar
+        run: |
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+# Perform all the clean up
+# ------------------------
+
+  swell-tier_1-clean_up_success:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+
+    steps:
+
+      - name: Remove the run directory
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+
+  swell-tier_1-clean_up_always:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    if: always()  # Always run the clean up, even if failed or cancelled
+
+    steps:
+
+      - name: Remove the cylc logging directories
+        run: |
+          rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+
+      - name: Remove the R2D2 experiment output
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -319,4 +319,4 @@ jobs:
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
-    
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -39,30 +39,6 @@ jobs:
           pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-
-  #check_hash_on_discover_test:
-
-  #  runs-on: nccs-discover
-  #  timeout-minutes: 600
-  #  needs: swell-tier_2-setup
-
-  #  steps:
-
-  #    - name: run-check_hash_test
-  #      run: |
-  #        CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-  #        source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-  #        # Get python version
-  #        PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-  #        export PATH=$CI_WORKSPACE/swell/bin:$PATH
-  #        export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          #run check hash test script
-  #        python $CI_WORKSPACE/swell/lib/python$PYVER/site-packages/swell/test/platform_tests/check_hashes_discover.py
-
-
   # --------------------------------------------
   # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
   # --------------------------------------------

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -208,7 +208,7 @@ jobs:
           COMPARISON_SUITE=3dfgat_cycle
           SUITE_NAME=${COMPARISON_SUITE}-comparison
 
-          CONFIG_NAME=compare_variational_marine
+          CONFIG_NAME=compare_fgat_marine
 
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_1-setup:
+  swell-tier_2-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,39 +20,47 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run ufo_testing workflow
-  # ------------------------
-  swell-tier_1-ufo_testing:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-setup
 
     steps:
 
-      - name: run-swell-ufo_testing
+      - name: run-swell-build_jedi
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -69,42 +77,48 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
   # Move experiment directory on failure
-  swell-tier_1-ufo_testing-failure:
+  swell-tier_2-build_jedi-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-ufo_testing
+    needs: swell-tier_2-build_jedi
     if: failure()
 
     steps:
-      - name: Fail hold for ufo_testing
+      - name: Fail hold for build_jedi
         run: |
-          SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
 
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+
+  # Run ncdiag convesion suite
+  swell-tier_2-convert_ncdiags:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
-      - name: run-swell-hofx
+      - name: run-swell-convert_ncdiags
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=convert_ncdiags
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -115,6 +129,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -122,40 +140,40 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
+  swell-tier_2-convert_ncdiags-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-hofx
+    needs: swell-tier_2-convert_ncdiags
     if: failure()
 
     steps:
-      - name: Fail hold for hofx
+      - name: Fail hold for convert_ncdiags
         run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=convert_ncdiags
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
+
+  # Run 3dvar suite
+  swell-tier_2-3dvar:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-3dvar
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -166,6 +184,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -173,90 +195,39 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
+  swell-tier_2-3dvar-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar
+    needs: swell-tier_2-3dvar
     if: failure()
 
     steps:
       - name: Fail hold for 3dvar
         run: |
           SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
+  # Run 3dfgat_atmos suite
+  swell-tier_2-3dfgat_atmos:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_atmos
-        run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-3dfgat_atmos
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -267,6 +238,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -274,51 +249,181 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
+  swell-tier_2-3dfgat_atmos-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
+    needs: swell-tier_2-3dfgat_atmos
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_atmos
         run: |
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-# Perform all the clean up
-# ------------------------
-
-  swell-tier_1-clean_up_success:
+  # Run ufo_testing suite
+  swell-tier_2-ufo_testing:
 
     runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    timeout-minutes: 600
+    needs: swell-tier_2-build_jedi
 
     steps:
 
-      - name: Remove the run directory
+      - name: run-swell-ufo_testing
         run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
-  swell-tier_1-clean_up_always:
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_2-ufo_testing-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: swell-tier_2-ufo_testing
+    if: failure()
+
+    steps:
+      - name: Fail hold for ufo_testing
+        run: |
+          SUITE_NAME=ufo_testing
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run hofx suite
+  swell-tier_2-hofx:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_2-build_jedi
+
+    steps:
+
+      - name: run-swell-hofx
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_2-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-hofx
+    if: failure()
+
+    steps:
+      - name: Fail hold for hofx
+        run: |
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
+
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_2-convert_ncdiags, swell-tier_2-ufo_testing, swell-tier_2-hofx, swell-tier_2-3dvar, swell-tier_2-3dfgat_atmos]
+
+    steps:
+      - name: Replace link to stable with link to current run and remove old directory
+        run: |
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
+
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
+        run: |
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
+
+  swell-tier_2-clean_up:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_2-convert_ncdiags, swell-tier_2-ufo_testing, swell-tier_2-hofx, swell-tier_2-3dvar, swell-tier_2-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
+          rm -r -f $HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -40,27 +40,27 @@ jobs:
           # Remove source code (needed to ensure nothing relies on the source)
 
 
-  check_hash_on_discover_test:
+  #check_hash_on_discover_test:
 
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-setup
+  #  runs-on: nccs-discover
+  #  timeout-minutes: 600
+  #  needs: swell-tier_2-setup
 
-    steps:
+  #  steps:
 
-      - name: run-check_hash_test
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+  #    - name: run-check_hash_test
+  #      run: |
+  #        CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+  #        source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+  #        # Get python version
+  #        PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+  #        export PATH=$CI_WORKSPACE/swell/bin:$PATH
+  #        export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
           #run check hash test script
-          python $CI_WORKSPACE/swell/lib/python$PYVER/site-packages/swell/test/platform_tests/check_hashes_discover.py
+  #        python $CI_WORKSPACE/swell/lib/python$PYVER/site-packages/swell/test/platform_tests/check_hashes_discover.py
 
 
   # --------------------------------------------

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -6,6 +6,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier2
+
 jobs:
 
   # Define the suite list once
@@ -25,7 +28,7 @@ jobs:
   define-comparison-matrix:
     runs-on: nccs-discover
     outputs:
-      comparison_suites: ${{ steps.set-comparison-suites.out }}
+      comparison_suites: ${{ steps.set-comparison-suites.outputs.comparisons_suites }}
       comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
     steps:
       - name: Set comparison suite list

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -226,7 +226,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11012025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-12092025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
@@ -269,7 +269,7 @@ jobs:
       - name: run-swell-3dfgat_atmos
         run: |
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
+          SUITE_NAME=3dfgat_atmos_tier2
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
@@ -329,7 +329,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11012025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-12092025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -85,6 +85,58 @@ jobs:
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
                 - name: Copy cylc Logs
 
+  # Run 3dfgat_cycle workflow
+  # ------------------------
+  swell-tier_1-3dfgat_cycle:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_cycle
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_cycle-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_cycle
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_cycle
+        run: |
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
+
   # Run hofx workflow
   # -----------------
   swell-tier_1-hofx:
@@ -295,7 +347,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
 
     steps:
 
@@ -307,7 +359,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -317,6 +369,7 @@ jobs:
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -195,8 +195,8 @@ jobs:
 
   swell-tier2-3dfgat_cycle-comparison:
 
-    runs_on: nccs-discover
-    timeout_minutes: 30
+    runs-on: nccs-discover
+    timeout-minutes: 30
     needs: swell-tier_2-3dfgat_cycle
 
     steps:
@@ -296,8 +296,8 @@ jobs:
 
   swell-tier2-3dfgat_atmos-comparison:
 
-    runs_on: nccs-discover
-    timeout_minutes: 30
+    runs-on: nccs-discover
+    timeout-minutes: 30
     needs: swell-tier_2-3dfgat_atmos
 
     steps:

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 2 Applications Tests (Discover)
+name: Swell Tier 1 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_2-setup:
+  swell-tier_1-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,47 +20,39 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
-      # Only one tier 2 run is allowed at a given time
-      - name: establish-workflow-status
-        run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
-
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # --------------------------------------------
-  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
-  # --------------------------------------------
-
-  swell-tier_2-build_jedi:
+  # Run 3dvar_cycle workflow
+  # ------------------------
+  swell-tier_1-3dvar_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
+    needs: swell-tier_1-setup
 
     steps:
 
-      - name: run-swell-build_jedi
+      - name: run-swell-3dvar_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -77,102 +69,42 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
-
   # Move experiment directory on failure
-  swell-tier_2-build_jedi-failure:
+  swell-tier_1-3dvar_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-3dvar_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for build_jedi
+      - name: Fail hold for 3dvar_cycle
         run: |
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=3dvar_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
 
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-
-  # Run hofx suite
-  swell-tier_2-hofx:
+  # Run 3dfgat_cycle workflow
+  # ------------------------
+  swell-tier_1-3dfgat_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_cycle suite
-  swell-tier_2-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
 
     steps:
 
       - name: run-swell-3dfgat_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -182,10 +114,6 @@ jobs:
 
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
@@ -193,89 +121,194 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  swell-tier2-3dfgat_cycle-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
-
-    steps:
-      - name: run-swell-3dfgat_cycle-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_cycle
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_fgat_marine
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-12092025
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
   # Move experiment directory on failure
-  swell-tier_2-3dfgat_cycle-failure:
+  swell-tier_1-3dfgat_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
+    needs: swell-tier_1-3dfgat_cycle
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_cycle
         run: |
           SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
 
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
+  # Run hofx workflow
+  # -----------------
+  swell-tier_1-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-hofx
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-hofx-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-hofx
+    if: failure()
+
+    steps:
+      - name: Fail hold for hofx
+        run: |
+          SUITE_NAME=hofx
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar workflow
+  # -----------------
+  swell-tier_1-3dvar:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar
+        run: |
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
 
     steps:
 
       - name: run-swell-3dfgat_atmos
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -286,121 +319,99 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME}_tier2 -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_atmos-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-
-    steps:
-      - name: run-swell-3dfgat_atmos-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_atmos
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_variational_atmosphere
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-12092025
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
+  swell-tier_1-3dfgat_atmos-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
+    needs: swell-tier_1-3dfgat_atmos
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_atmos
         run: |
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-  
-  # -------------------------------------------------------------
-  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
-  # -------------------------------------------------------------
 
-  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
-  # --------------------------
-  swell-tier_2-update_if_stable:
+
+  # Run localensembleda workflow
+  # -----------------
+  swell-tier_1-localensembleda:
 
     runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
 
     steps:
-      - name: Replace link to stable with link to current run and remove old directory
+
+      - name: run-swell-localensembleda
         run: |
-          # Get full path to previous sucessful run
-          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=localensembleda
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
-          # Remove link
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+          mkdir -p $CI_WORKSPACE_JOB
 
-          # Link to new stable
-          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
-          # Remove old stable
-          echo "Removing previous stable: $previous_stable"
-          rm -r -f $previous_stable
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
-      # Remove the running lock if the update was sucessful
-      - name: Remove the running lock
-        run: |
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-  # Perform all the clean up (always runs regardless of success of failure)
-  # ------------------------
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-  swell-tier_2-clean_up:
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-localensembleda-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
+    needs: swell-tier_1-localensembleda
+    if: failure()
+
+    steps:
+      - name: Fail hold for localensembleda
+        run: |
+          SUITE_NAME=localensembleda
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+# Perform all the clean up
+# ------------------------
+
+  swell-tier_1-clean_up_success:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+
+    steps:
+
+      - name: Remove the run directory
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+
+  swell-tier_1-clean_up_always:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -408,15 +419,13 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-localensembleda-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -6,426 +6,109 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
+
 jobs:
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda"]'
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  # ------------------------------------------
   swell-tier_1-setup:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-
+    needs: define-matrix
     steps:
       - name: validate-workflow
-        run: |
-          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
+        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
-          # Remove source code (needed to ensure nothing relies on the source)
+          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
 
-  # Run 3dvar_cycle workflow
-  # ------------------------
-  swell-tier_1-3dvar_cycle:
-
+  # Run all test workflows using matrix
+  swell-tier_1-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: [define-matrix, swell-tier_1-setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-3dvar_cycle
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          EOF
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_cycle
+      - name: Mark failed on failure
+        if: failure()
         run: |
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-  # Run 3dfgat_cycle workflow
-  # ------------------------
-  swell-tier_1-3dfgat_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
-
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-hofx
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar
-        run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_atmos
-        run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-
-  # Run localensembleda workflow
-  # -----------------
-  swell-tier_1-localensembleda:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-localensembleda
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-localensembleda-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-localensembleda
-    if: failure()
-
-    steps:
-      - name: Fail hold for localensembleda
-        run: |
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-# Perform all the clean up
-# ------------------------
-
+  # Cleanup on success
   swell-tier_1-clean_up_success:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
-
+    needs: [define-matrix, swell-tier_1-test]
     steps:
-
       - name: Remove the run directory
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
+  # Cleanup always (cylc logs and R2D2)
   swell-tier_1-clean_up_always:
-
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
-    if: always()  # Always run the clean up, even if failed or cancelled
-
+    needs: [define-matrix, swell-tier_1-test]
+    if: always()
     steps:
-
-      - name: Remove the cylc logging directories
+      - name: Remove cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-localensembleda-${GITHUB_RUN_ID}-suite
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
+          done
 
-      - name: Remove the R2D2 experiment output
+      - name: Remove R2D2 experiment output
         run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${suite}-${GITHUB_RUN_ID}
+          done

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -33,9 +33,9 @@ jobs:
           pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run ufo_testing workflow
+  # Run 3dvar_cycle workflow
   # ------------------------
-  swell-tier_1-ufo_testing:
+  swell-tier_1-3dvar_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
@@ -43,10 +43,10 @@ jobs:
 
     steps:
 
-      - name: run-swell-ufo_testing
+      - name: run-swell-3dvar_cycle
         run: |
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=ufo_testing
+          SUITE_NAME=3dvar_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
@@ -70,17 +70,17 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-ufo_testing-failure:
+  swell-tier_1-3dvar_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-ufo_testing
+    needs: swell-tier_1-3dvar_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for ufo_testing
+      - name: Fail hold for 3dvar_cycle
         run: |
-          SUITE_NAME=ufo_testing
+          SUITE_NAME=3dvar_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
                 - name: Copy cylc Logs
@@ -295,7 +295,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
 
     steps:
 
@@ -307,16 +307,16 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 2 Applications Tests (Discover)
+name: Swell Tier 1 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_2-setup:
+  swell-tier_1-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,268 +20,39 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
-      # Only one tier 2 run is allowed at a given time
-      - name: establish-workflow-status
-        run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
-
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # --------------------------------------------
-  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
-  # --------------------------------------------
-
-  swell-tier_2-build_jedi:
+  # Run ufo_testing workflow
+  # ------------------------
+  swell-tier_1-ufo_testing:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
-
-    steps:
-
-      - name: run-swell-build_jedi
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
-
-  # Move experiment directory on failure
-  swell-tier_2-build_jedi-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-build_jedi
-    if: failure()
-
-    steps:
-      - name: Fail hold for build_jedi
-        run: |
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-
-  # Run ncdiag convesion suite
-  swell-tier_2-convert_ncdiags:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-convert_ncdiags
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=convert_ncdiags
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-convert_ncdiags-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-convert_ncdiags
-    if: failure()
-
-    steps:
-      - name: Fail hold for convert_ncdiags
-        run: |
-          SUITE_NAME=convert_ncdiags
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-
-  # Run 3dvar suite
-  swell-tier_2-3dvar:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dvar
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dvar-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dvar
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar
-        run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run ufo_testing suite
-  swell-tier_2-ufo_testing:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
 
     steps:
 
       - name: run-swell-ufo_testing
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -292,50 +63,48 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-ufo_testing-failure:
+  swell-tier_1-ufo_testing-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-ufo_testing
+    needs: swell-tier_1-ufo_testing
     if: failure()
 
     steps:
       - name: Fail hold for ufo_testing
         run: |
           SUITE_NAME=ufo_testing
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+                - name: Copy cylc Logs
 
-  # Run hofx suite
-  swell-tier_2-hofx:
+  # Run hofx workflow
+  # -----------------
+  swell-tier_1-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: swell-tier_1-setup
 
     steps:
 
       - name: run-swell-hofx
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -346,84 +115,210 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
+  swell-tier_1-hofx-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-hofx
+    needs: swell-tier_1-hofx
     if: failure()
 
     steps:
       - name: Fail hold for hofx
         run: |
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # -------------------------------------------------------------
-  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
-  # -------------------------------------------------------------
-
-  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
-  # --------------------------
-  swell-tier_2-update_if_stable:
+  # Run 3dvar workflow
+  # -----------------
+  swell-tier_1-3dvar:
 
     runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-convert_ncdiags, swell-tier_2-ufo_testing, swell-tier_2-hofx, swell-tier_2-3dvar, swell-tier_2-3dfgat_atmos]
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
 
     steps:
-      - name: Replace link to stable with link to current run and remove old directory
+
+      - name: run-swell-3dvar
         run: |
-          # Get full path to previous sucessful run
-          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
-          # Remove link
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
+          mkdir -p $CI_WORKSPACE_JOB
 
-          # Link to new stable
-          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
-          # Remove old stable
-          echo "Removing previous stable: $previous_stable"
-          rm -r -f $previous_stable
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
-      # Remove the running lock if the update was sucessful
-      - name: Remove the running lock
-        run: |
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
-  # Perform all the clean up (always runs regardless of success of failure)
-  # ------------------------
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-  swell-tier_2-clean_up:
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-convert_ncdiags, swell-tier_2-ufo_testing, swell-tier_2-hofx, swell-tier_2-3dvar, swell-tier_2-3dfgat_atmos]
+    needs: swell-tier_1-3dvar
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar
+        run: |
+          SUITE_NAME=3dvar
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dvar_atmos workflow
+  # -----------------
+  swell-tier_1-3dvar_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dvar_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dvar_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dvar_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dvar_atmos
+        run: |
+          SUITE_NAME=3dvar_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_atmos
+        run: |
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+# Perform all the clean up
+# ------------------------
+
+  swell-tier_1-clean_up_success:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+
+    steps:
+
+      - name: Remove the run directory
+        run: |
+          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+
+  swell-tier_1-clean_up_always:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-convert_ncdiags-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -226,7 +226,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-10142025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
@@ -329,7 +329,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-10142025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -215,6 +215,8 @@ jobs:
 
           mkdir -p $CI_WORKSPACE_JOB
 
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
@@ -228,7 +230,7 @@ jobs:
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
 
           echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
@@ -316,6 +318,8 @@ jobs:
 
           mkdir -p $CI_WORKSPACE_JOB
 
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
 
@@ -329,7 +333,7 @@ jobs:
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
 
           echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Set suite list
         id: set-suites
         run: |
-          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda"]'
+          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda", "hofx_cf"]'
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda" >> $GITHUB_OUTPUT
+          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda hofx_cf" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
   swell-tier_1-setup:
@@ -50,6 +50,7 @@ jobs:
     needs: [define-matrix, swell-tier_1-setup]
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
@@ -94,7 +95,7 @@ jobs:
       - name: Remove the run directory
         run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
-  # Cleanup always (cylc logs and R2D2)
+  # Cleanup always (cylc logs)
   swell-tier_1-clean_up_always:
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -105,10 +106,4 @@ jobs:
         run: |
           for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
             rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
-          done
-
-      - name: Remove R2D2 experiment output
-        run: |
-          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
-            rm -rf /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${suite}-${GITHUB_RUN_ID}
           done

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_1-setup:
+  swell-tier_2-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,39 +20,47 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run 3dvar_cycle workflow
-  # ------------------------
-  swell-tier_1-3dvar_cycle:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-setup
 
     steps:
 
-      - name: run-swell-3dvar_cycle
+      - name: run-swell-build_jedi
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -69,94 +77,48 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
   # Move experiment directory on failure
-  swell-tier_1-3dvar_cycle-failure:
+  swell-tier_2-build_jedi-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar_cycle
+    needs: swell-tier_2-build_jedi
     if: failure()
 
     steps:
-      - name: Fail hold for 3dvar_cycle
+      - name: Fail hold for build_jedi
         run: |
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
 
-  # Run 3dfgat_cycle workflow
-  # ------------------------
-  swell-tier_1-3dfgat_cycle:
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+
+  # Run hofx suite
+  swell-tier_2-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
-
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-hofx
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -167,6 +129,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -174,40 +140,39 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
+  swell-tier_2-hofx-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-hofx
+    needs: swell-tier_2-hofx
     if: failure()
 
     steps:
       - name: Fail hold for hofx
         run: |
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
+  # Run 3dfgat_cycle suite
+  swell-tier_2-3dfgat_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
-      - name: run-swell-3dvar
+      - name: run-swell-3dfgat_cycle
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -218,47 +183,37 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
+  swell-tier2-3dfgat_cycle-comparison:
 
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
+    runs_on: nccs-discover
+    timeout_minutes: 30
+    needs: swell-tier_2-3dfgat_cycle
 
     steps:
-      - name: Fail hold for 3dvar
+      - name: run-swell-3dfgat_cycle-comparison
         run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          COMPARISON_SUITE=3dfgat_cycle
+          SUITE_NAME=${COMPARISON_SUITE}-comparison
 
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+          CONFIG_NAME=compare_variational_marine
 
-    steps:
-
-      - name: run-swell-3dvar_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -269,46 +224,56 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
+  swell-tier_2-3dfgat_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
+    needs: swell-tier_2-3dfgat_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for 3dvar_atmos
+      - name: Fail hold for 3dfgat_cycle
         run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
+  # Run 3dfgat_atmos suite
+  swell-tier_2-3dfgat_atmos:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-3dfgat_atmos
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -319,112 +284,119 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+  swell-tier2-3dfgat_atmos-comparison:
+
+    runs_on: nccs-discover
+    timeout_minutes: 30
+    needs: swell-tier_2-3dfgat_atmos
+
+    steps:
+      - name: run-swell-3dfgat_atmos-comparison
+        run: |
+
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          
+          COMPARISON_SUITE=3dfgat_atmos
+          SUITE_NAME=${COMPARISON_SUITE}-comparison
+
+          CONFIG_NAME=compare_variational_atmosphere
+
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          EXPERIMENT_ID_1=${COMPARISON_SUITE}-10142025
+          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
+
+          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=${CI_WORKSPACE}/${GITHUB_RUN_ID}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+
+          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
   # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
+  swell-tier_2-3dfgat_atmos-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
+    needs: swell-tier_2-3dfgat_atmos
     if: failure()
 
     steps:
       - name: Fail hold for 3dfgat_atmos
         run: |
           SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+  
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
 
-  # Run localensembleda workflow
-  # -----------------
-  swell-tier_1-localensembleda:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-localensembleda
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-localensembleda-failure:
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-localensembleda
-    if: failure()
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
 
     steps:
-      - name: Fail hold for localensembleda
+      - name: Replace link to stable with link to current run and remove old directory
         run: |
-          SUITE_NAME=localensembleda
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
 
-# Perform all the clean up
-# ------------------------
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
 
-  swell-tier_1-clean_up_success:
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
+
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
+
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
+        run: |
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
+
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
+
+  swell-tier_2-clean_up:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs:
-          - swell-tier_1-3dvar_cycle
-          - swell-tier_1-3dfgat_cycle
-          - swell-tier_1-hofx
-          - swell-tier_1-3dvar
-          - swell-tier_1-3dvar_atmos
-          - swell-tier_1-3dfgat_atmos
-          - swell-tier_1-localensembleda
-
-    steps:
-
-      - name: Remove the run directory
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-
-  swell-tier_1-clean_up_always:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs:
-          - swell-tier_1-3dvar_cycle
-          - swell-tier_1-3dfgat_cycle
-          - swell-tier_1-hofx
-          - swell-tier_1-3dvar
-          - swell-tier_1-3dvar_atmos
-          - swell-tier_1-3dfgat_atmos
-          - swell-tier_1-localensembleda
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -432,13 +404,15 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-localsensembleda-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -226,7 +226,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-10142025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11042025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -236,6 +236,56 @@ jobs:
         run: |
           SUITE_NAME=3dvar_atmos
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+
+  # Run 3dfgat_atmos workflow
+  # -----------------
+  swell-tier_1-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_1-setup
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_1-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_1-3dfgat_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_atmos
+        run: |
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
 # Perform all the clean up
@@ -245,7 +295,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
 
     steps:
 
@@ -257,7 +307,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos]
+    needs: [swell-tier_1-ufo_testing, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -266,6 +316,9 @@ jobs:
         run: |
           rm -r -f $HOME/cylc-run/swell-ufo_testing-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 1 Applications Tests (Discover)
+name: Swell Tier 2 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -10,7 +10,7 @@ jobs:
 
   # Initialization needed by all the workflows
   # ------------------------------------------
-  swell-tier_1-setup:
+  swell-tier_2-setup:
 
     runs-on: nccs-discover
     timeout-minutes: 30
@@ -20,39 +20,47 @@ jobs:
         run: |
           /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
+      # Only one tier 2 run is allowed at a given time
+      - name: establish-workflow-status
+        run: |
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
-  # Run 3dvar_cycle workflow
-  # ------------------------
-  swell-tier_1-3dvar_cycle:
+  # --------------------------------------------
+  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
+  # --------------------------------------------
+
+  swell-tier_2-build_jedi:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-setup
 
     steps:
 
-      - name: run-swell-3dvar_cycle
+      - name: run-swell-build_jedi
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -69,94 +77,48 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
+          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
+          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+
   # Move experiment directory on failure
-  swell-tier_1-3dvar_cycle-failure:
+  swell-tier_2-build_jedi-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar_cycle
+    needs: swell-tier_2-build_jedi
     if: failure()
 
     steps:
-      - name: Fail hold for 3dvar_cycle
+      - name: Fail hold for build_jedi
         run: |
-          SUITE_NAME=3dvar_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          SUITE_NAME=build_jedi
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
 
-  # Run 3dfgat_cycle workflow
-  # ------------------------
-  swell-tier_1-3dfgat_cycle:
+
+  # ----------------------------------------
+  # STEP2: RUN TESTING SUITES WITH NEW BUILD
+  # ----------------------------------------
+
+  # Run hofx suite
+  swell-tier_2-hofx:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_cycle-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_cycle
-        run: |
-          SUITE_NAME=3dfgat_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-                - name: Copy cylc Logs
-
-  # Run hofx workflow
-  # -----------------
-  swell-tier_1-hofx:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+    needs: swell-tier_2-build_jedi
 
     steps:
 
       - name: run-swell-hofx
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
@@ -167,6 +129,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
           cd $CI_WORKSPACE_JOB
@@ -174,192 +140,61 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_1-hofx-failure:
+  swell-tier_2-hofx-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-hofx
+    needs: swell-tier_2-hofx
     if: failure()
 
     steps:
       - name: Fail hold for hofx
         run: |
           SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dvar workflow
-  # -----------------
-  swell-tier_1-3dvar:
+  # -------------------------------------------------------------
+  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
+  # -------------------------------------------------------------
 
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dvar
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar-failure:
+  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
+  # --------------------------
+  swell-tier_2-update_if_stable:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar
-    if: failure()
+    needs: [swell-tier_2-hofx]
 
     steps:
-      - name: Fail hold for 3dvar
+      - name: Replace link to stable with link to current run and remove old directory
         run: |
-          SUITE_NAME=3dvar
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+          # Get full path to previous sucessful run
+          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
 
-  # Run 3dvar_atmos workflow
-  # -----------------
-  swell-tier_1-3dvar_atmos:
+          # Remove link
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
 
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
+          # Link to new stable
+          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
 
-    steps:
+          # Remove old stable
+          echo "Removing previous stable: $previous_stable"
+          rm -r -f $previous_stable
 
-      - name: run-swell-3dvar_atmos
+      # Remove the running lock if the update was sucessful
+      - name: Remove the running lock
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
 
-          mkdir -p $CI_WORKSPACE_JOB
+  # Perform all the clean up (always runs regardless of success of failure)
+  # ------------------------
 
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dvar_atmos-failure:
+  swell-tier_2-clean_up:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_1-3dvar_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dvar_atmos
-        run: |
-          SUITE_NAME=3dvar_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-
-  # Run 3dfgat_atmos workflow
-  # -----------------
-  swell-tier_1-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_1-setup
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_1-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_1-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-# Perform all the clean up
-# ------------------------
-
-  swell-tier_1-clean_up_success:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
-
-    steps:
-
-      - name: Remove the run directory
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/swell/tier1/${GITHUB_RUN_ID}
-
-  swell-tier_1-clean_up_always:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_1-3dvar_cycle, swell-tier_1-3dfgat_cycle, swell-tier_1-hofx, swell-tier_1-3dvar, swell-tier_1-3dvar_atmos, swell-tier_1-3dfgat_atmos]
+    needs: [swell-tier_2-hofx]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -367,12 +202,9 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dvar_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
+

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -226,7 +226,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11042025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11012025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
@@ -329,7 +329,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-10142025
+          EXPERIMENT_ID_1=swell-${COMPARISON_SUITE}-11012025
           COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/SwellExperiments/${EXPERIMENT_ID_1}/${EXPERIMENT_ID_1}-suite/experiment.yaml
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -154,6 +154,114 @@ jobs:
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
+  # Run 3dfgat_cycle suite
+  swell-tier_2-3dfgat_cycle:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_2-build_jedi
+
+    steps:
+
+      - name: run-swell-3dfgat_cycle
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_2-3dfgat_cycle-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-3dfgat_cycle
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_cycle
+        run: |
+          SUITE_NAME=3dfgat_cycle
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+
+  # Run 3dfgat_atmos suite
+  swell-tier_2-3dfgat_atmos:
+
+    runs-on: nccs-discover
+    timeout-minutes: 600
+    needs: swell-tier_2-build_jedi
+
+    steps:
+
+      - name: run-swell-3dfgat_atmos
+        run: |
+          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+
+          mkdir -p $CI_WORKSPACE_JOB
+
+          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+
+          # Get python version
+          PYVER=`python --version | awk '{print $2}' | awk -F. '{print $1"."$2}'`
+
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          # Point to the active build
+          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+  # Move experiment directory on failure
+  swell-tier_2-3dfgat_atmos-failure:
+
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: swell-tier_2-3dfgat_atmos
+    if: failure()
+
+    steps:
+      - name: Fail hold for 3dfgat_atmos
+        run: |
+          SUITE_NAME=3dfgat_atmos
+          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+  
   # -------------------------------------------------------------
   # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
   # -------------------------------------------------------------
@@ -164,7 +272,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
 
     steps:
       - name: Replace link to stable with link to current run and remove old directory
@@ -194,7 +302,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -202,9 +310,13 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+    

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -132,7 +132,7 @@ jobs:
   swell-tier_2-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
+    needs: [define-matrix, swell-tier_2-build_jedi]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -179,7 +179,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-comparison-matrix, swell-tier_2-setup, swell-tier_2-test]
+    needs: [define-comparison-matrix, swell-tier_2-test]
     strategy:
       fail-fast: false
       max-parallel: 5

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -29,10 +29,20 @@ jobs:
             "3dfgat_atmos"
             "localensembleda"
             "hofx_cf"
-            # "3dvar_cf"
+            "3dvar_cf"
           )
-          # Convert array to JSON and space-separated string
-          SUITES=$(printf '%s\n' "${SUITES_ARR[@]}" | jq -R . | jq -sc .)
+          
+          # Build JSON array explicitly (because jq command doesn't exist)
+          SUITES='["'
+          for i in "${!SUITES_ARR[@]}"; do
+            if [ $i -lt $((${#SUITES_ARR[@]} - 1)) ]; then
+              SUITES+="${SUITES_ARR[$i]}\",\""
+            else
+              SUITES+="${SUITES_ARR[$i]}"
+            fi
+          done
+          SUITES+='"]'
+          
           SUITES_SPACE="${SUITES_ARR[*]}"
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
           echo "suites_space=$SUITES_SPACE" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -29,7 +29,7 @@ jobs:
             "3dfgat_atmos"
             "localensembleda"
             "hofx_cf"
-            "3dvar_cf"
+            # "3dvar_cf"
           )
           
           # Build JSON array explicitly (because jq command doesn't exist)

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -145,7 +145,7 @@ jobs:
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
-          EXPERIMENT_ID=swell${SUITE_NAME}-${GITHUB_RUN_ID}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
           source ${CI_WORKSPACE}/modules
@@ -158,8 +158,8 @@ jobs:
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
-          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source"
-          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build"
+          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source
+          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -20,9 +20,22 @@ jobs:
       - name: Set suite list
         id: set-suites
         run: |
-          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda", "hofx_cf", "3dvar_cf"]'
+          SUITES_ARR=(
+            "3dvar_marine_cycle"
+            "3dfgat_marine_cycle"
+            "hofx"
+            "3dvar_marine"
+            "3dvar_atmos"
+            "3dfgat_atmos"
+            "localensembleda"
+            "hofx_cf"
+            # "3dvar_cf"
+          )
+          # Convert array to JSON and space-separated string
+          SUITES=$(printf '%s\n' "${SUITES_ARR[@]}" | jq -R . | jq -sc .)
+          SUITES_SPACE="${SUITES_ARR[*]}"
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda hofx_cf 3dvar_cf" >> $GITHUB_OUTPUT
+          echo "suites_space=$SUITES_SPACE" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
   swell-tier_1-setup:

--- a/.github/workflows/test_swell.yml
+++ b/.github/workflows/test_swell.yml
@@ -1,4 +1,4 @@
-name: Swell Tier 2 Applications Tests (Discover)
+name: Swell Tier 1 Applications Tests (Discover)
 
 on: workflow_call
 
@@ -7,10 +7,9 @@ defaults:
     shell: bash
 
 env:
-  CI_BASE: /discover/nobackup/gmao_ci/swell/tier2
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier1
 
 jobs:
-
   # Define the suite list once
   define-matrix:
     runs-on: nccs-discover
@@ -21,118 +20,34 @@ jobs:
       - name: Set suite list
         id: set-suites
         run: |
-          SUITES='["hofx", "3dfgat_cycle", "3dfgat_atmos"]'
+          SUITES='["3dvar_cycle", "3dfgat_cycle", "hofx", "3dvar", "3dvar_atmos", "3dfgat_atmos", "localensembleda", "hofx_cf", "3dvar_cf"]'
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "suites_space=hofx 3dfgat_cycle 3dfgat_atmos" >> $GITHUB_OUTPUT
-
-  define-comparison-matrix:
-    runs-on: nccs-discover
-    outputs:
-      comparison_suites: ${{ steps.set-comparison-suites.outputs.comparisons_suites }}
-      comparison_suites_space: ${{ steps.set-comparison-suites.outputs.comparison_suites_space }}
-    steps:
-      - name: Set comparison suite list
-        id: set-comparison-suites
-        run: |
-          SUITES='["3dfgat_cycle", "3dfgat_atmos"]'
-          echo "comparison_suites=$SUITES" >> $GITHUB_OUTPUT
-          echo "comparison_suites_space=3dfgat_cycle-comparison 3dfgat_atmos-comparison" >> $GITHUB_OUTPUT
+          echo "suites_space=3dvar_cycle 3dfgat_cycle hofx 3dvar 3dvar_atmos 3dfgat_atmos localensembleda hofx_cf 3dvar_cf" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
-  # ------------------------------------------
-  swell-tier_2-setup:
-
+  swell-tier_1-setup:
     runs-on: nccs-discover
     timeout-minutes: 30
     needs: define-matrix
     steps:
       - name: validate-workflow
-        run: |
-          /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
-
-      # Only one tier 2 run is allowed at a given time
-      - name: establish-workflow-status
-        run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+        run: /home/jardizzo/bin/nams_check.py ${{ github.triggering_actor }} swell
 
       - name: acquire-swell
         uses: actions/checkout@v3
 
       - name: install-swell
         run: |
-          # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
-          # Remove source code (needed to ensure nothing relies on the source)
+          mkdir ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
 
-  # --------------------------------------------
-  # STEP1: BUILD JEDI CODE FROM DEVELOP BRANCHES
-  # --------------------------------------------
-
-  swell-tier_2-build_jedi:
-
+  # Run all test workflows using matrix
+  swell-tier_1-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
-
-    steps:
-
-      - name: run-swell-build_jedi
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
-
-  # Move experiment directory on failure
-  swell-tier_2-build_jedi-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-build_jedi
-    if: failure()
-
-    steps:
-      - name: Fail hold for build_jedi
-        run: |
-          SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-  swell-tier_2-test:
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: [define-matrix, swell-tier_2-build_jedi]
+    needs: [define-matrix, swell-tier_1-setup]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -150,16 +65,13 @@ jobs:
           mkdir -p $CI_WORKSPACE_JOB
           source ${CI_WORKSPACE}/modules
 
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
           export PATH=$CI_WORKSPACE/swell/bin:$PATH
           export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
 
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
-          existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source
-          existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
@@ -174,119 +86,24 @@ jobs:
           CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-
-  swell-tier_2-comparison:
-
+  # Cleanup on success
+  swell-tier_1-clean_up_success:
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [define-comparison-matrix, swell-tier_2-test]
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix:
-        suite: ${{ fromJson(needs.define-comparison-matrix.outputs.comparison_suites) }}
-
+    needs: [define-matrix, swell-tier_1-test]
     steps:
-      - name: run-swell-${{ matrix.suite }}-comparison
-        run: |
+      - name: Remove the run directory
+        run: rm -rf ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          SUITE_NAME=${{ matrix.suite }}-comparison
-
-          if [ "${{ matrix.suite }}" == "3dfgat_cycle" ]; then
-            CONFIG_NAME=compare_fgat_marine
-          else
-            CONFIG_NAME=compare_variational_atmosphere
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "publish_directory: /discover/nobackup/gmao_ci/swell_publication_location" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          COMPARISON_EXP_PATH_1=/discover/nobackup/gmao_ci/swell/tier2/stable/${SUITE_NAME}/swell-${SUITE_NAME}-*/swell-${SUITE_NAME}-*-suite/experiment.yaml
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # -------------------------------------------------------------
-  # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
-  # -------------------------------------------------------------
-
-  # Update the nightly pointer (only runs if tier 1 tests were sucessful)
-  # --------------------------
-  swell-tier_2-update_if_stable:
-
+  # Cleanup always (cylc logs)
+  swell-tier_1-clean_up_always:
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-test, swell-tier_2-comparison]
-
+    needs: [define-matrix, swell-tier_1-test]
+    if: always()
     steps:
-      - name: Replace link to stable with link to current run and remove old directory
+      - name: Remove cylc logging directories
         run: |
-          # Get full path to previous sucessful run
-          previous_stable=`readlink -f /discover/nobackup/gmao_ci/swell/tier2/stable`
-
-          # Remove link
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/stable
-
-          # Link to new stable
-          ln -sf /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID} /discover/nobackup/gmao_ci/swell/tier2/stable
-
-          # Remove old stable
-          echo "Removing previous stable: $previous_stable"
-          rm -r -f $previous_stable
-
-      # Remove the running lock if the update was sucessful
-      - name: Remove the running lock
-        run: |
-          rm -f /discover/nobackup/gmao_ci/swell/tier2/__running__
-
-  # Perform all the clean up (always runs regardless of success of failure)
-  # ------------------------
-
-  swell-tier_2-clean_up:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: [swell-tier_2-test, swell-tier_2-comparison]
-    if: always()  # Always run the clean up, even if failed or cancelled
-
-    steps:
-      - name: Remove the cylc logging directories
-        run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
-
-      - name: Remove the R2D2 experiment output
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS
+          for suite in ${{ needs.define-matrix.outputs.suites_space }}; do
+            rm -rf $HOME/cylc-run/swell-${suite}-${GITHUB_RUN_ID}-suite
+          done


### PR DESCRIPTION
The number of suites that CI-workflow is running is increasing. We should have the list line-by-line for readability (Couldn't use `jq` for brevity).

3dvar_cf is commented out until that PR is merged in SWELL and this PR can supersede https://github.com/GEOS-ESM/CI-workflows/pull/31

⚠️  https://github.com/GEOS-ESM/swell/pull/677 Should go in before this can be merged.