### PR TITLE
Switch to 3dfgat_marine_cycle in tier2

### DIFF
--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -154,8 +154,8 @@ jobs:
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-  # Run 3dfgat_cycle suite
-  swell-tier_2-3dfgat_cycle:
+  # Run 3dfgat_marine_cycle suite
+  swell-tier_2-3dfgat_marine_cycle:
 
     runs-on: nccs-discover
     timeout-minutes: 600
@@ -163,10 +163,10 @@ jobs:
 
     steps:
 
-      - name: run-swell-3dfgat_cycle
+      - name: run-swell-3dfgat_marine_cycle
         run: |
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_cycle
+          SUITE_NAME=3dfgat_marine_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
@@ -193,19 +193,19 @@ jobs:
           swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  swell-tier2-3dfgat_cycle-comparison:
+  swell-tier2-3dfgat_marine_cycle-comparison:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
+    needs: swell-tier_2-3dfgat_marine_cycle
 
     steps:
-      - name: run-swell-3dfgat_cycle-comparison
+      - name: run-swell-3dfgat_marine_cycle-comparison
         run: |
 
           CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
           
-          COMPARISON_SUITE=3dfgat_cycle
+          COMPARISON_SUITE=3dfgat_marine_cycle
           SUITE_NAME=${COMPARISON_SUITE}-comparison
 
           CONFIG_NAME=compare_fgat_marine
@@ -226,7 +226,7 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_cycle-comparison")
+          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_marine_cycle-comparison")
 
           EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
           COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
@@ -242,17 +242,17 @@ jobs:
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
   # Move experiment directory on failure
-  swell-tier_2-3dfgat_cycle-failure:
+  swell-tier_2-3dfgat_marine_cycle-failure:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_cycle
+    needs: swell-tier_2-3dfgat_marine_cycle
     if: failure()
 
     steps:
-      - name: Fail hold for 3dfgat_cycle
+      - name: Fail hold for 3dfgat_marine_cycle
         run: |
-          SUITE_NAME=3dfgat_cycle
+          SUITE_NAME=3dfgat_marine_cycle
           CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
@@ -368,7 +368,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_marine_cycle, swell-tier_2-3dfgat_atmos]
 
     steps:
       - name: Replace link to stable with link to current run and remove old directory
@@ -398,7 +398,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
+    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_marine_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_marine_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
     if: always()  # Always run the clean up, even if failed or cancelled
 
     steps:
@@ -406,15 +406,15 @@ jobs:
       - name: Remove the cylc logging directories
         run: |
           rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_marine_cycle-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_cycle-comparison-${GITHUB_RUN_ID}-suite
+          rm -r -f $HOME/cylc-run/swell-3dfgat_marine_cycle-comparison-${GITHUB_RUN_ID}-suite
           rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_cycle-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_marine_cycle-${GITHUB_RUN_ID}
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS


### PR DESCRIPTION
I'm trying to resolve issues with #30, with it skipping the comparison tests. So for now, this updates the tier2 config to use the newly renamed `3dfgat_marine_cycle` suite. We can update the comparison version using the symlinks, that doesn't need to be a PR