### PR TITLE
Switch tier2 tests to matrices, and other changes

### DIFF
--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -82,7 +82,10 @@ jobs:
         run: |
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
-          rm ${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
+
+          FAIL_FLAG=${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
+          if [ -f $FAIL_FLAG ]; then rm $FAIL_FLAG; fi
+          
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -82,8 +82,8 @@ jobs:
         run: |
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
+          rm ${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
-          rm __${CI_WORKSPACE_JOB}_FAILED__
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
@@ -107,8 +107,7 @@ jobs:
       - name: Mark failed on failure
         if: failure()
         run: |
-          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
-          touch __${CI_WORKSPACE_JOB}_FAILED__ || true
+          touch ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/__${{ matrix.suite }}_FAILED__
 
   # Cleanup on success
   swell-tier_1-clean_up_success:

--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -83,6 +83,7 @@ jobs:
           CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=${{ matrix.suite }}
           CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
+          rm __${CI_WORKSPACE_JOB}_FAILED__
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
@@ -107,7 +108,7 @@ jobs:
         if: failure()
         run: |
           CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
+          touch __${CI_WORKSPACE_JOB}_FAILED__ || true
 
   # Cleanup on success
   swell-tier_1-clean_up_success:

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -24,6 +24,7 @@ jobs:
             "hofx"
             "3dfgat_marine_cycle"
             "3dfgat_atmos"
+            "3dvar_cf"
           )
 
           # Build JSON array explicitly (because jq command doesn't exist)
@@ -153,7 +154,7 @@ jobs:
           FAIL_FLAG=${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
           if [ -f $FAIL_FLAG ]; then rm $FAIL_FLAG; fi
           
-          if [ "${SUITE_NAME}" != "hofx" ]; then
+          if [[ "${SUITE_NAME}" != "hofx" && "${SUITE_NAME}" != "3dvar_cf" ]]; then
             CONFIG_NAME="${SUITE_NAME}_tier2"
           else
             CONFIG_NAME="${SUITE_NAME}"
@@ -209,6 +210,8 @@ jobs:
             CONFIG_NAME=compare_fgat_marine
           elif [ "${{ matrix.suite }}" == "3dfgat_atmos" ]; then
             CONFIG_NAME=compare_variational_atmosphere
+          elif [ "${{ matrix.suite }}" == "3dvar_cf" ]; then
+            CONFIG_NAME=compare_variational_cf
           else
             exit 0
           fi

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -42,12 +42,10 @@ jobs:
           echo "suites=$SUITES" >> $GITHUB_OUTPUT
           echo "suites_space=$SUITES_SPACE" >> $GITHUB_OUTPUT
 
-  # Initialization needed by all the workflows
-  # ------------------------------------------
-  swell-tier_2-setup:
-
+  # Initialization needed by the workflow
+  establish-workflow:
     runs-on: nccs-discover
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
       - name: validate-workflow
@@ -60,6 +58,13 @@ jobs:
           if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
             touch /discover/nobackup/gmao_ci/swell/tier2/__running__
 
+  # Installation of swell
+  # ---------------------
+  swell-tier_2-setup:
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: establish-workflow
+    steps:
       - name: acquire-swell
         uses: actions/checkout@v3
 
@@ -81,42 +86,53 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-setup
-
+    needs: establish-workflow
     steps:
-      - name: run-swell-build_jedi
+      - name: build_jedi
         run: |
-          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
 
-          mkdir -p $CI_WORKSPACE_JOB
+          FAIL_FLAG=${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
+          if [ -f $FAIL_FLAG ]; then rm $FAIL_FLAG; fi
 
-          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          git clone https://github.com/GEOS-ESM/jedi_bundle ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/src
+          source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle -r ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/src/requirements.txt --no-cache-dir --ignore-installed ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/src
 
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
 
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+          export PATH=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/bin:$PATH
+          export PYTHONPATH=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/lib/python$PYVER/site-packages:$PYTHONPATH
+          
+          BUILD_PATH=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_build
+          mkdir -p $BUILD_PATH
+          cd $BUILD_PATH
+          
+          jedi_bundle
+          jedi_bundle clone build.yaml
 
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          cat > build_jedi.sh <<EOF
+          #!/bin/bash
+          #SBATCH --job-name=BuildJedi
+          #SBATCH --qos=dastest
+          #SBATCH --partition=preops
+          #SBATCH --time=02:00:00
+          #SBATCH --constraint=mil
+          #SBATCH --nodes=1
+          #SBATCH --account=g0613
+          #SBATCH --output=build_jedi.out
+          #SBATCH --error=build_jedi.err
+          
+          source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel
+          export PATH=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/bin:$PATH
+          export PYTHONPATH=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_bundle/lib/python$PYVER/site-packages:$PYTHONPATH
 
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__use_existing__" ]; then
-            echo "Using current pinned version of JEDI"
-            echo "jedi_build_method: use_existing" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          fi
+          jedi_bundle configure build.yaml
+          jedi_bundle make build.yaml
+          EOF
 
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-          # Create symbolic link to build that does not involve $GITHUB_RUN_ID
-          ln -s $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/jedi_bundle $CI_WORKSPACE_JOB/jedi_bundle
+          sbatch --wait ./build_jedi.sh
 
   # Move experiment directory on failure
   swell-tier_2-build_jedi-failure:
@@ -130,8 +146,8 @@ jobs:
       - name: Fail hold for build_jedi
         run: |
           SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          touch ${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
 
   # Run all test workflows using matrix
   swell-tier_2-test:
@@ -173,8 +189,8 @@ jobs:
           cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
           experiment_id: $EXPERIMENT_ID
           experiment_root: $CI_WORKSPACE_JOB
-          existing_jedi_source_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source
-          existing_jedi_build_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build
+          existing_jedi_source_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_build/
+          existing_jedi_build_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/jedi_build/build-intel-release
           EOF
 
           rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -306,8 +306,3 @@ jobs:
           rm -rf $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
           rm -rf $HOME/cylc-run/swell-${{ matrix.suite }}-${GITHUB_RUN_ID}-suite
           rm -rf $HOME/cylc-run/swell-${{ matrix.suite }}-comparison-${GITHUB_RUN_ID}-suite
-
-      - name: Remove the R2D2 experiment output
-        run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${{ matrix.suite }}-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
             touch /discover/nobackup/gmao_ci/swell/tier2/__running__
-          echo "hi"
 
       - name: acquire-swell
         uses: actions/checkout@v3

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -6,7 +6,40 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_BASE: /discover/nobackup/gmao_ci/swell/tier2
+
 jobs:
+  # Define the suite list once
+  define-matrix:
+    runs-on: nccs-discover
+    outputs:
+      suites: ${{ steps.set-suites.outputs.suites }}
+      suites_space: ${{ steps.set-suites.outputs.suites_space }}
+    steps:
+      - name: Set suite list
+        id: set-suites
+        run: |
+          SUITES_ARR=(
+            "hofx"
+            "3dfgat_marine_cycle"
+            "3dfgat_atmos"
+          )
+
+          # Build JSON array explicitly (because jq command doesn't exist)
+          SUITES='["'
+          for i in "${!SUITES_ARR[@]}"; do
+            if [ $i -lt $((${#SUITES_ARR[@]} - 1)) ]; then
+              SUITES+="${SUITES_ARR[$i]}\",\""
+            else
+              SUITES+="${SUITES_ARR[$i]}"
+            fi
+          done
+          SUITES+='"]'
+
+          SUITES_SPACE="${SUITES_ARR[*]}"
+          echo "suites=$SUITES" >> $GITHUB_OUTPUT
+          echo "suites_space=$SUITES_SPACE" >> $GITHUB_OUTPUT
 
   # Initialization needed by all the workflows
   # ------------------------------------------
@@ -23,8 +56,9 @@ jobs:
       # Only one tier 2 run is allowed at a given time
       - name: establish-workflow-status
         run: |
-          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+          #if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+          #touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+          echo "hi"
 
       - name: acquire-swell
         uses: actions/checkout@v3
@@ -32,11 +66,11 @@ jobs:
       - name: install-swell
         run: |
           # Make experiment directory
-          mkdir -p /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          mkdir -p ${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           # Copy and source modules
-          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-          pip install --prefix=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
+          cp ${GITHUB_WORKSPACE}/src/swell/deployment/platforms/nccs_discover_sles15/modules ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
+          pip install --prefix=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/swell -r ${GITHUB_WORKSPACE}/requirements.txt --no-cache-dir ${GITHUB_WORKSPACE}
           # Remove source code (needed to ensure nothing relies on the source)
 
   # --------------------------------------------
@@ -50,17 +84,16 @@ jobs:
     needs: swell-tier_2-setup
 
     steps:
-
       - name: run-swell-build_jedi
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
           SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
@@ -70,6 +103,11 @@ jobs:
 
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__use_existing__" ]; then
+            echo "Using current pinned version of JEDI"
+            echo "jedi_build_method: use_existing" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
+          fi
 
           rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
 
@@ -92,130 +130,95 @@ jobs:
       - name: Fail hold for build_jedi
         run: |
           SUITE_NAME=build_jedi
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${SUITE_NAME}
           mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
 
-
-  # ----------------------------------------
-  # STEP2: RUN TESTING SUITES WITH NEW BUILD
-  # ----------------------------------------
-
-  # Run hofx suite
-  swell-tier_2-hofx:
-
+  # Run all test workflows using matrix
+  swell-tier_2-test:
     runs-on: nccs-discover
     timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-build_jedi]
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
-
-      - name: run-swell-hofx
+      - name: run-swell-${{ matrix.suite }}
         run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          SUITE_NAME=${{ matrix.suite }}
 
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-hofx-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-hofx
-    if: failure()
-
-    steps:
-      - name: Fail hold for hofx
-        run: |
-          SUITE_NAME=hofx
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_marine_cycle suite
-  swell-tier_2-3dfgat_marine_cycle:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_marine_cycle
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_marine_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_marine_cycle-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_marine_cycle
-
-    steps:
-      - name: run-swell-3dfgat_marine_cycle-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
+          FAIL_FLAG=${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
+          if [ -f $FAIL_FLAG ]; then rm $FAIL_FLAG; fi
           
-          COMPARISON_SUITE=3dfgat_marine_cycle
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
+          if [ "${SUITE_NAME}" != "hofx" ]; then
+            CONFIG_NAME="${SUITE_NAME}_tier2"
+          else
+            CONFIG_NAME="${SUITE_NAME}"
+          fi
+          echo "config name: ${SUITE_NAME}"
 
-          CONFIG_NAME=compare_fgat_marine
+          CI_WORKSPACE_JOB=${CI_WORKSPACE}/${SUITE_NAME}
+          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
+          mkdir -p $CI_WORKSPACE_JOB
+          source ${CI_WORKSPACE}/modules
+
+          PYVER=$(python --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
+          export PATH=$CI_WORKSPACE/swell/bin:$PATH
+          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
+
+          cat > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml <<EOF
+          experiment_id: $EXPERIMENT_ID
+          experiment_root: $CI_WORKSPACE_JOB
+          existing_jedi_source_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source
+          existing_jedi_build_directory: ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build
+          EOF
+
+          rm -rf $HOME/cylc-run/${EXPERIMENT_ID}-suite
+
+          cd $CI_WORKSPACE_JOB
+          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml -s /home/gmao_ci/.swell/slurm-directives.yaml
+          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
+
+      - name: Mark failed on failure
+        if: failure()
+        run: |
+          touch ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/__${{ matrix.suite }}_FAILED__
+
+  # Run comparison tests using matrix
+  swell-tier_2-comparison:
+    runs-on: nccs-discover
+    timeout-minutes: 30
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-test]
+    strategy:
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
+
+    steps:
+      - name: run-swell-${{ matrix.suite }}-comparison
+        run: |
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+
+          SUITE_NAME=${{ matrix.suite }}-comparison
+
+          # Set the config name
+          if [ "${{ matrix.suite }}" == "3dfgat_marine_cycle" ]; then
+            CONFIG_NAME=compare_fgat_marine
+          elif [ "${{ matrix.suite }}" == "3dfgat_atmos" ]; then
+            CONFIG_NAME=compare_variational_atmosphere
+          else
+            exit 0
+          fi
+
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${SUITE_NAME}
           EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
 
           mkdir -p $CI_WORKSPACE_JOB
 
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
+          source ${{ env.CI_BASE }}/${GITHUB_RUN_ID}/modules
 
           # Get python version
           PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
@@ -226,10 +229,10 @@ jobs:
           echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
 
-          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_marine_cycle-comparison")
+          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-${{ matrix.suite }}-comparison")
 
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
+          EXPERIMENT_ID_2=swell-${{ matrix.suite }}-${GITHUB_RUN_ID}
+          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${{ matrix.suite }}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
 
           echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
@@ -241,123 +244,12 @@ jobs:
           swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
           swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
 
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_marine_cycle-failure:
+      - name: Mark failed on failure
+        if: failure()
+        run : |
+          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}_comparison
+          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
 
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_marine_cycle
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_marine_cycle
-        run: |
-          SUITE_NAME=3dfgat_marine_cycle
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-
-  # Run 3dfgat_atmos suite
-  swell-tier_2-3dfgat_atmos:
-
-    runs-on: nccs-discover
-    timeout-minutes: 600
-    needs: swell-tier_2-build_jedi
-
-    steps:
-
-      - name: run-swell-3dfgat_atmos
-        run: |
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          # Point to the active build
-          echo "existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/source" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/build_jedi/jedi_bundle/build" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${SUITE_NAME}_tier2 -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  swell-tier2-3dfgat_atmos-comparison:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-
-    steps:
-      - name: run-swell-3dfgat_atmos-comparison
-        run: |
-
-          CI_WORKSPACE=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}
-          
-          COMPARISON_SUITE=3dfgat_atmos
-          SUITE_NAME=${COMPARISON_SUITE}-comparison
-
-          CONFIG_NAME=compare_variational_atmosphere
-
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          EXPERIMENT_ID=swell-${SUITE_NAME}-${GITHUB_RUN_ID}
-
-          mkdir -p $CI_WORKSPACE_JOB
-
-          source /discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/modules
-
-          # Get python version
-          PYVER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-
-          export PATH=$CI_WORKSPACE/swell/bin:$PATH
-          export PYTHONPATH=${PYTHONPATH}:$CI_WORKSPACE/swell/lib/python$PYVER/site-packages
-
-          echo "experiment_id: $EXPERIMENT_ID" > $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "experiment_root: $CI_WORKSPACE_JOB" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          COMPARISON_EXP_PATH_1=$(realpath "/discover/nobackup/gmao_ci/SwellExperiments/current-3dfgat_atmos-comparison")
-
-          EXPERIMENT_ID_2=swell-${COMPARISON_SUITE}-${GITHUB_RUN_ID}
-          COMPARISON_EXP_PATH_2=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${COMPARISON_SUITE}/${EXPERIMENT_ID_2}/${EXPERIMENT_ID_2}-suite/experiment.yaml
-
-          echo "comparison_experiment_paths:" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_1" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          echo "- $COMPARISON_EXP_PATH_2" >> $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-
-          rm -r -f $HOME/cylc-run/${EXPERIMENT_ID}-suite
-
-          cd $CI_WORKSPACE_JOB
-          swell create ${CONFIG_NAME} -m defaults -p nccs_discover_sles15 -o $CI_WORKSPACE_JOB/${SUITE_NAME}-override.yaml
-          swell launch $CI_WORKSPACE_JOB/${EXPERIMENT_ID}/${EXPERIMENT_ID}-suite --no-detach --log_path $CI_WORKSPACE_JOB/${EXPERIMENT_ID}
-
-  # Move experiment directory on failure
-  swell-tier_2-3dfgat_atmos-failure:
-
-    runs-on: nccs-discover
-    timeout-minutes: 30
-    needs: swell-tier_2-3dfgat_atmos
-    if: failure()
-
-    steps:
-      - name: Fail hold for 3dfgat_atmos
-        run: |
-          SUITE_NAME=3dfgat_atmos
-          CI_WORKSPACE_JOB=/discover/nobackup/gmao_ci/swell/tier2/${GITHUB_RUN_ID}/${SUITE_NAME}
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED
-  
   # -------------------------------------------------------------
   # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP
   # -------------------------------------------------------------
@@ -368,7 +260,7 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_marine_cycle, swell-tier_2-3dfgat_atmos]
+    needs: [swell-tier_2-test, swell-tier_2-comparison]
 
     steps:
       - name: Replace link to stable with link to current run and remove old directory
@@ -398,23 +290,21 @@ jobs:
 
     runs-on: nccs-discover
     timeout-minutes: 30
-    needs: [swell-tier_2-hofx, swell-tier_2-3dfgat_marine_cycle, swell-tier_2-3dfgat_atmos, swell-tier2-3dfgat_marine_cycle-comparison, swell-tier2-3dfgat_atmos-comparison]
+    needs: [define-matrix, swell-tier_2-setup, swell-tier_2-test, swell-tier_2-comparison]
     if: always()  # Always run the clean up, even if failed or cancelled
+    strategy:
+      matrix:
+        suite: ${{ fromJson(needs.define-matrix.outputs.suites) }}
 
     steps:
 
       - name: Remove the cylc logging directories
         run: |
-          rm -r -f $HOME/cylc-run/swell-hofx-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_marine_cycle-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_marine_cycle-comparison-${GITHUB_RUN_ID}-suite
-          rm -r -f $HOME/cylc-run/swell-3dfgat_atmos-comparison-${GITHUB_RUN_ID}-suite
+          rm -rf $HOME/cylc-run/swell-build_jedi-${GITHUB_RUN_ID}-suite
+          rm -rf $HOME/cylc-run/swell-${{ matrix.suite }}-${GITHUB_RUN_ID}-suite
+          rm -rf $HOME/cylc-run/swell-${{ matrix.suite }}-comparison-${GITHUB_RUN_ID}-suite
 
       - name: Remove the R2D2 experiment output
         run: |
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-hofx-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_marine_cycle-${GITHUB_RUN_ID}
-          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-3dfgat_atmos-${GITHUB_RUN_ID}
+          rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/ncdiag/ob/swell-${{ matrix.suite }}-${GITHUB_RUN_ID}
           rm -r -f /discover/nobackup/gmao_ci/R2D2DataStore/Local/mom6_cice6_UFS

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -57,8 +57,8 @@ jobs:
       # Only one tier 2 run is allowed at a given time
       - name: establish-workflow-status
         run: |
-          #if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
-          #touch /discover/nobackup/gmao_ci/swell/tier2/__running__
+          if [ -f "/discover/nobackup/gmao_ci/swell/tier2/__running__" ]; then echo "Tier 2 is already running. Abort"; exit 1; fi
+            touch /discover/nobackup/gmao_ci/swell/tier2/__running__
           echo "hi"
 
       - name: acquire-swell

--- a/.github/workflows/swell-tier2_application_discover.yml
+++ b/.github/workflows/swell-tier2_application_discover.yml
@@ -249,8 +249,9 @@ jobs:
       - name: Mark failed on failure
         if: failure()
         run : |
-          CI_WORKSPACE_JOB=${{ env.CI_BASE }}/${GITHUB_RUN_ID}/${{ matrix.suite }}_comparison
-          mv $CI_WORKSPACE_JOB ${CI_WORKSPACE_JOB}_FAILED || true
+          SUITE_NAME=${{ matrix.suite }}-comparison
+          CI_WORKSPACE=${{ env.CI_BASE }}/${GITHUB_RUN_ID}
+          touch ${CI_WORKSPACE}/__${SUITE_NAME}_FAILED__
 
   # -------------------------------------------------------------
   # STEP3: PERFORM UPDATES OF STABLE NIGHTLY POINTER AND CLEAN UP

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ This repository contains reusable GitHub Actions workflows for the Swell test pi
 4. Run the tier-2 application suites (`hofx`, `3dfgat_marine_cycle`, and `3dfgat_atmos`) against that build.
 5. Run comparison jobs for the marine and atmosphere suites.
 6. On success, update the stable pointer; on failure, mark failed work directories with `_FAILED`; and always clean up logs and output data.
+
+## Contributing
+
+Please check out our [contributing guidelines](CONTRIBUTING.md).
+
+## License
+
+All files are currently licensed under the Apache-2.0 license, see [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Test repository for CI Workflows
 
-## Contributing
+This repository contains reusable GitHub Actions workflows for the Swell test pipelines used on Discover.
 
-Please check out our [contributing guidelines](CONTRIBUTING.md).
+## Swell workflow steps
 
-## License
+### Tier 1 workflow (`.github/workflows/swell-tier1_application_discover.yml`)
 
-All files are currently licensed under the Apache-2.0 license, see [`LICENSE`](LICENSE).
+1. Build a matrix of Swell suites to run in parallel.
+2. Validate the workflow, check out the repository, and install the Swell Python environment.
+3. Launch each suite in its own job using the matrix.
+4. If a suite fails, rename its working directory to `<suite>_FAILED`.
+5. Clean up the run directory and Cylc log directories.
+
+### Tier 2 workflow (`.github/workflows/swell-tier2_application_discover.yml`)
+
+1. Create a lock so only one tier-2 run proceeds at a time.
+2. Install Swell and prepare a per-run workspace.
+3. Build the JEDI bundle using the `jedi_bundle` module on Discover
+4. Run the tier-2 application suites (`hofx`, `3dfgat_marine_cycle`, and `3dfgat_atmos`) against that build.
+5. Run comparison jobs for the marine and atmosphere suites.
+6. On success, update the stable pointer; on failure, mark failed work directories with `_FAILED`; and always clean up logs and output data.


### PR DESCRIPTION
This PR changes tier2 tests to use the matrix formulation. It also allows detecting a flag called `__use_existing__` to decide whether to build jedi or not (for debugging purposes). It also changes the behavior of a failed suite, so that it no longer moves the directories, instead leaving a flag to note when a suite is failed (#36)