### PR TITLE
Add convert_ncdiags to tier1

### DIFF
--- a/.github/workflows/swell-tier1_application_discover.yml
+++ b/.github/workflows/swell-tier1_application_discover.yml
@@ -30,6 +30,7 @@ jobs:
             # "localensembleda"
             "hofx_cf"
             "3dvar_cf"
+            "convert_ncdiags"
           )
           
           # Build JSON array explicitly (because jq command doesn't exist)


### PR DESCRIPTION
Since `convert_ncdiags` now works as of GEOS-ESM/swell#835, we can add it to tier1 tests. Tested on CI test branch.